### PR TITLE
feat: improve skill scores for hmem

### DIFF
--- a/skills/hmem-config/SKILL.md
+++ b/skills/hmem-config/SKILL.md
@@ -1,25 +1,19 @@
 ---
 name: hmem-config
-description: >
-  View and change hmem memory settings, hooks, sync, and checkpoint configuration.
-  Use this skill whenever the user types /hmem-config, asks to change memory settings,
-  adjust parameters, tune bulk-read behavior, configure auto-checkpoints, manage
-  hmem-sync, or troubleshoot memory-related issues. Also trigger when the user asks
-  things like "how often does auto-save fire", "why is my context so large",
-  "change checkpoint to auto", "how many tokens does startup cost", or "set up sync".
+description: "View and change hmem memory settings, hooks, sync, and checkpoint configuration. Use this skill whenever the user types /hmem-config, asks to change memory settings, adjust parameters, tune bulk-read behavior, configure auto-checkpoints, manage hmem-sync, or troubleshoot memory-related issues. Also trigger when the user asks things like 'how often does auto-save fire', 'why is my context so large', 'change checkpoint to auto', 'how many tokens does startup cost', or 'set up sync'."
 ---
 
 # hmem-config — View and Change Settings
 
-This skill guides you through reading, explaining, and updating hmem's configuration. The config controls how memory is stored, displayed, checkpointed, and synced across devices.
+This skill guides the agent through reading, explaining, and updating hmem's configuration. The config controls how memory is stored, displayed, checkpointed, and synced across devices.
 
 ## Locate and read the config
 
-The config lives at `hmem.config.json` in the same directory as your .hmem file. Located at `~/.hmem/hmem.config.json` (in the same directory as your .hmem file).
+Config path: `~/.hmem/hmem.config.json` (same directory as the .hmem file).
 
-Read the file directly — don't ask the user where it is. If it doesn't exist, offer to create one (only non-default values need to be specified).
+Read the file directly — do not ask the user where it is. If it does not exist, offer to create one with only non-default values.
 
-The config uses a unified format with a `"memory"` block and an optional `"sync"` block:
+The config uses a `"memory"` block and an optional `"sync"` block:
 
 ```json
 {
@@ -30,107 +24,64 @@ The config uses a unified format with a `"memory"` block and an optional `"sync"
 
 ## Show current settings
 
-Present a table of current values vs. defaults. Only highlight values that differ from defaults — the user cares about what they've customized, not the full list.
+Present a table of current values vs. defaults. Only highlight values that differ from defaults.
 
 ### Core parameters
 
-| Parameter | Default | Purpose |
-|-----------|---------|---------|
-| `maxCharsPerLevel` | [200, 2500, 10000, 25000, 50000] | Character limits per tree level [L1–L5]. L1 is always loaded at startup, so keeping it short saves tokens across every session. L5 is raw data, rarely accessed. |
-| `maxDepth` | 5 | Tree depth (1–5). Most users need 5. Lower values save storage but lose granularity. |
-| `defaultReadLimit` | 100 | Max entries per bulk read. Lower = faster startup, higher = more complete overview. |
-| `maxTitleChars` | 50 | Auto-extracted title length. Only applies to entries without explicit body separation — entries with a blank-line body use the first line as title verbatim. Titles are navigation labels — too short truncates meaning, too long wastes space. |
-| `accessCountTopN` | 5 | Entries with highest access count get [★] and auto-expand in bulk reads. These are "organic favorites" — the things the agent keeps coming back to. |
+| Parameter | Default | Range |
+|-----------|---------|-------|
+| `maxCharsPerLevel` | [200, 2500, 10000, 25000, 50000] | L1: 60–300, L5: 1000–100000 |
+| `maxDepth` | 5 | 2–5 |
+| `defaultReadLimit` | 100 | Positive integer |
+| `maxTitleChars` | 50 | Positive integer |
+| `accessCountTopN` | 5 | Positive integer |
+
+- `maxCharsPerLevel`: Character limits per tree level [L1–L5]. L1 loads at every startup — keep it short to save tokens. L5 is raw data, rarely accessed.
+- `accessCountTopN`: Entries with highest access count get [★] and auto-expand in bulk reads.
 
 ### Checkpoint and session parameters (v5+)
 
-These control the automatic knowledge extraction pipeline:
+| Parameter | Default | Range |
+|-----------|---------|-------|
+| `checkpointMode` | `"remind"` | `"auto"` or `"remind"` |
+| `checkpointInterval` | 20 | 0–100 |
+| `recentOEntries` | 10 | 0–20 |
+| `contextTokenThreshold` | 100000 | 0–500000 |
 
-| Parameter | Default | Purpose |
-|-----------|---------|---------|
-| `checkpointMode` | `"remind"` | **`"auto"`** spawns a Haiku subagent in the background every N exchanges — it reads the conversation, extracts lessons/errors/decisions, and writes them via MCP tools. The main agent is never interrupted. **`"remind"`** injects a prompt asking the main agent to save manually — simpler but interrupts flow. |
-| `checkpointInterval` | 20 | Exchanges between checkpoints. Counted in the active O-entry, not per session — so 10 messages on your laptop + 10 on your server = checkpoint fires at 20. Set to 0 to disable. |
-| `recentOEntries` | 10 | How many recent session logs to show when loading a project. All entries include full user/agent exchanges (L4/L5), not just titles. Higher = more context but more tokens at project load. |
-| `contextTokenThreshold` | 100000 | When cumulative hmem output exceeds this, the agent is told to flush context and /clear. Prevents runaway token usage in long sessions. Set to 0 to disable. |
+- `checkpointMode`: `"auto"` spawns a Haiku subagent in the background every N exchanges to extract lessons/errors/decisions via MCP tools without interrupting the main agent. `"remind"` injects a prompt asking the main agent to save manually.
+- `checkpointInterval`: Counted in the active O-entry, not per session. Set to 0 to disable.
+- `recentOEntries`: Recent session logs shown at project load. Higher = more context but more tokens.
+- `contextTokenThreshold`: When cumulative hmem output exceeds this, the agent flushes context and /clear. Set to 0 to disable.
 
 ### Entry schemas (v6.3.0+)
 
-Define per-prefix section schemas that control `create_project` structure and `load_project` rendering depth. When a schema is defined, it replaces the hardcoded R0009 sections and the `loadProjectExpand` settings.
-
-```json
-{
-  "memory": {
-    "schemas": {
-      "P": {
-        "sections": [
-          { "name": "Overview",    "loadDepth": 3, "defaultChildren": ["Current state", "Goals", "Environment"] },
-          { "name": "Codebase",    "loadDepth": 1 },
-          { "name": "Protocol",    "loadDepth": 0 },
-          { "name": "Next Steps",  "loadDepth": 3 }
-        ],
-        "createLinkedO": true
-      }
-    }
-  }
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sections[].name` | string | L2 section title. Used for matching during auto-reconcile (case-insensitive). |
-| `sections[].loadDepth` | 0-4 | 0=skip, 1=title only, 2=+L3 titles, 3=+L3 body, 4=full subtree |
-| `sections[].defaultChildren` | string[] | L3 nodes created by `create_project`. Optional. |
-| `createLinkedO` | boolean | Auto-create matching O-entry on `create_project`. Default: false. |
-
-**Auto-reconcile:** On every `load_project`, missing schema sections are automatically added as empty L2 nodes. Extra sections not in the schema are kept (loaded at depth 1).
-
-**No schema defined:** Falls back to hardcoded R0009 behavior and `loadProjectExpand` settings.
-
-### load_project display (legacy, pre-v6.3.0)
-
-Only used when no `schemas` entry exists for the prefix. Controls which P-entry sections are expanded:
-
-| Parameter | Default | Purpose |
-|-----------|---------|---------|
-| `loadProjectExpand.withBody` | `[1]` | L2 section seq numbers where L3 children show title + body content. Default: `.1 Overview` — shows full architecture/state/goals detail. |
-| `loadProjectExpand.withChildren` | `[6, 8]` | L2 section seq numbers where all L3 children are listed as titles. Default: `.6 Bugs`, `.8 Open Tasks` — all items visible at a glance. |
-
-Sections not in either list show L3 titles only in compact mode.
+See [references/SCHEMAS.md](references/SCHEMAS.md) for schema definitions, field reference, auto-reconcile behavior, and legacy `loadProjectExpand` settings.
 
 ### Bulk-read tuning
 
-The bulk-read algorithm decides which entries get expanded (full L2 detail) vs. compressed (title only). Most users don't need to touch these — the defaults work well up to ~500 entries.
-
-| Parameter | Default | Purpose |
-|-----------|---------|---------|
-| `bulkReadV2.topNewestCount` | 5 | Newest entries expanded. Increase if you want more recent context at startup. |
-| `bulkReadV2.topAccessCount` | 3 | Most-accessed entries expanded (time-weighted: `access_count / log2(age_days + 2)`). |
-| `bulkReadV2.topObsoleteCount` | 3 | Obsolete entries kept visible — "biggest mistakes" are still worth seeing. |
-| `bulkReadV2.topSubnodeCount` | 3 | Entries with most children expanded. These tend to be the most detailed/important. |
+See [references/BULK-READ.md](references/BULK-READ.md) for the bulk-read algorithm parameters and tuning recipes.
 
 ### Prefixes
 
-Default: P, L, T, E, D, M, S, N, H, R, O, I. Custom prefixes are merged with defaults — they don't replace them. Each prefix can have a custom description used as group header in bulk reads.
+Default: P, L, T, E, D, M, S, N, H, R, O, I. Custom prefixes merge with defaults (do not replace). Each prefix can have a custom description used as group header in bulk reads.
 
 ## Help the user make changes
 
 For each parameter the user wants to change:
 
-1. **Explain the tradeoff** in plain language — what gets better, what gets worse
-2. **Show the recommended range** (see below)
+1. **Explain the tradeoff** — what gets better, what gets worse
+2. **Show the recommended range** from the tables above
 3. **Validate** before writing — numbers must be positive, arrays must be valid JSON
 
-### Recommended ranges
+### Recommended guidance
 
-| Parameter | Range | Guidance |
-|-----------|-------|----------|
-| `maxCharsPerLevel[0]` (L1) | 60–300 | Below 60 is too terse for useful summaries. Above 300 wastes tokens on every bulk read — L1 is loaded at every session start. |
-| `maxCharsPerLevel[4]` (L5) | 1000–100000 | Raw data storage. Higher allows more verbatim content but L5 is rarely loaded. |
-| `maxDepth` | 2–5 | 3 suffices for simple setups. 5 for multi-agent or complex projects. |
-| `checkpointMode` | `"auto"` or `"remind"` | Recommend `"auto"` — it's non-disruptive and produces better results because Haiku has MCP access to check for duplicates. Auto-checkpoints also write rolling summaries (`[CP]` nodes) and tag skill-dialog exchanges for filtering. |
-| `checkpointInterval` | 0–100 | 20 is a good balance. Lower = more frequent saves (more Haiku cost). 0 = disabled. |
-| `recentOEntries` | 0–20 | 10 is the sweet spot. With checkpoint summaries, `load_project` shows summary + recent exchanges only — much more compact than raw exchange dumps. |
-| `contextTokenThreshold` | 0–500000 | 100k is recommended for most models. Increase for 1M-context models. |
+| Parameter | Guidance |
+|-----------|----------|
+| `maxCharsPerLevel[0]` (L1) | Below 60 too terse; above 300 wastes tokens on every bulk read |
+| `checkpointMode` | Recommend `"auto"` — non-disruptive, Haiku has MCP access for dedup, writes rolling `[CP]` summaries |
+| `checkpointInterval` | 20 is a good balance. Lower = more frequent saves (more Haiku cost) |
+| `recentOEntries` | 10 is the sweet spot. With checkpoint summaries, `load_project` shows summary + recent exchanges only |
+| `contextTokenThreshold` | 100k for most models. Increase for 1M-context models |
 
 ### Common recipes
 
@@ -147,14 +98,13 @@ Increase `bulkReadV2.topAccessCount` and decrease `topNewestCount` — favor pro
 
 ## Write the updated config
 
-Write `hmem.config.json` with only non-default values. The config uses a `"memory"` wrapper:
+Write `hmem.config.json` with only non-default values. Use the `"memory"` wrapper:
 
 ```json
 {
   "memory": {
     "checkpointMode": "auto"
-  },
-  "sync": { ... }
+  }
 }
 ```
 
@@ -167,96 +117,16 @@ After writing, tell the user:
 
 Run this check as part of every /hmem-config invocation.
 
-**If installed** (`which hmem-sync`): run `npx hmem-sync status` and show server URL, user ID, last push/pull timestamps, and whether `HMEM_SYNC_PASSPHRASE` is set in `.mcp.json` (needed for auto-sync).
+**If installed** (`which hmem-sync`): run `npx hmem-sync status` and show server URL, user ID, last push/pull timestamps, and whether `HMEM_SYNC_PASSPHRASE` is set in `.mcp.json`.
 
-**If not installed**: explain that hmem-sync enables zero-knowledge encrypted cross-device sync (AES-256-GCM, server sees only opaque blobs), and offer to install it:
+**If not installed**: explain that hmem-sync enables zero-knowledge encrypted cross-device sync (AES-256-GCM) and offer to install:
 ```bash
 npm install -g hmem-sync
 npx hmem-sync connect
 ```
 
-### Sync troubleshooting
+For sync issues, see [references/SYNC-TROUBLESHOOTING.md](references/SYNC-TROUBLESHOOTING.md).
 
-| Problem | Fix |
-|---------|-----|
-| "Config not found" | Run `npx hmem-sync connect` |
-| 401 Token verification failed | Passphrase has special chars — set `HMEM_SYNC_PASSPHRASE` in .mcp.json env |
-| 0 entries after pull | `HMEM_PATH` filename must match between devices |
-| Update | `npm update -g hmem-sync` (always global, never inside a project) |
+## Hook configuration on Windows
 
-## Hook configuration on Windows (REQUIRED)
-
-On Windows, hook execution is fragile out of the box. Two issues bite every new user:
-
-**1. Git Bash routing** — On systems with Git for Windows installed, Claude Code may route hook commands through Git Bash (`bash.exe`). Its MSYS2 runtime crashes transiently with `add_item ("\??\C:\Program Files\Git", "/", ...) failed, errno 1` during cygheap init, killing the hook **before the command is even parsed**. Symptom: `UserPromptSubmit hook error` or `Stop hook error` with a bash.exe stacktrace.
-
-**2. Unix inline env-var syntax** — Commands like `HMEM_PATH=C:/... node ...` work in bash but break in cmd.exe and PowerShell. Symptom: `"HMEM_PATH" is not recognized as a command`.
-
-**The fix for Windows users (apply to every hook + statusLine):**
-
-```json
-{
-  "env": {
-    "HMEM_PATH": "C:/Users/<you>/.hmem/Agents/<AGENT>/<AGENT>.hmem"
-  },
-  "hooks": {
-    "UserPromptSubmit": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js hook-startup",
-            "shell": "powershell"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js log-exchange",
-            "shell": "powershell"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "clear",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js context-inject",
-            "shell": "powershell"
-          }
-        ]
-      }
-    ]
-  },
-  "statusLine": {
-    "type": "command",
-    "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js statusline",
-    "shell": "powershell"
-  }
-}
-```
-
-Two things to notice:
-- `"shell": "powershell"` on **every** hook command and on statusLine — forces native PowerShell, bypasses Git Bash entirely.
-- `HMEM_PATH` lives in the top-level `env` block, **not** inline in the command. Claude Code inherits the env block to every hook subprocess, regardless of shell.
-
-**Never use inline env-var syntax in hook commands on Windows.** `VAR=value command` is bash-only syntax and will silently break under cmd.exe or PowerShell.
-
-**Troubleshooting matrix:**
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `UserPromptSubmit hook error` (no stacktrace) | Inline `VAR=value` in command + cmd.exe parses it as a command name | Move env vars to `env` block, remove inline prefix |
-| `bash.exe: *** fatal error - add_item ... errno 1` | Git Bash MSYS2 runtime crashing at startup | Add `"shell": "powershell"` to every hook command |
-| Hooks silently do nothing (no errors) | Wrong shell interpreting the command, or project not active for session logging | Verify `"shell": "powershell"`, call `load_project(id="P00XX")` every session |
-
-**Note on `load_project` per-session:** The `active` flag on a P-entry persists in the database, but the "currently active project for session logging" is a per-session attribute. After every Claude Code restart, the agent must call `load_project(id="P00XX")` again, or exchanges will be logged to O0000 (no-project fallback) instead of the project's O-entry. Consider adding this to your project briefing or session-start routine.
+Windows hook execution requires special configuration to avoid Git Bash routing crashes and inline env-var syntax failures. See [references/WINDOWS-HOOKS.md](references/WINDOWS-HOOKS.md) for the required setup, full example config, and troubleshooting matrix.

--- a/skills/hmem-config/references/BULK-READ.md
+++ b/skills/hmem-config/references/BULK-READ.md
@@ -1,0 +1,20 @@
+# Bulk-Read Tuning
+
+The bulk-read algorithm decides which entries get expanded (full L2 detail) vs. compressed (title only). The defaults work well up to ~500 entries. Most users do not need to change these.
+
+## Parameters
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `bulkReadV2.topNewestCount` | 5 | Newest entries expanded. Increase for more recent context at startup. |
+| `bulkReadV2.topAccessCount` | 3 | Most-accessed entries expanded (time-weighted: `access_count / log2(age_days + 2)`). |
+| `bulkReadV2.topObsoleteCount` | 3 | Obsolete entries kept visible — "biggest mistakes" are still worth seeing. |
+| `bulkReadV2.topSubnodeCount` | 3 | Entries with most children expanded. These tend to be the most detailed/important. |
+
+## Tuning recipes
+
+**"Startup is too slow / uses too many tokens":**
+Reduce `topNewestCount` (e.g., 3) and `topAccessCount` (e.g., 2) to limit expanded entries at startup.
+
+**"I have 500+ entries and bulk reads are noisy":**
+Increase `topAccessCount` and decrease `topNewestCount` — favor proven entries over new ones.

--- a/skills/hmem-config/references/SCHEMAS.md
+++ b/skills/hmem-config/references/SCHEMAS.md
@@ -1,0 +1,47 @@
+# Entry Schemas (v6.3.0+)
+
+Define per-prefix section schemas that control `create_project` structure and `load_project` rendering depth. When a schema is defined, it replaces the hardcoded R0009 sections and the `loadProjectExpand` settings.
+
+```json
+{
+  "memory": {
+    "schemas": {
+      "P": {
+        "sections": [
+          { "name": "Overview",    "loadDepth": 3, "defaultChildren": ["Current state", "Goals", "Environment"] },
+          { "name": "Codebase",    "loadDepth": 1 },
+          { "name": "Protocol",    "loadDepth": 0 },
+          { "name": "Next Steps",  "loadDepth": 3 }
+        ],
+        "createLinkedO": true
+      }
+    }
+  }
+}
+```
+
+## Schema fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sections[].name` | string | L2 section title. Used for matching during auto-reconcile (case-insensitive). |
+| `sections[].loadDepth` | 0-4 | 0=skip, 1=title only, 2=+L3 titles, 3=+L3 body, 4=full subtree |
+| `sections[].defaultChildren` | string[] | L3 nodes created by `create_project`. Optional. |
+| `createLinkedO` | boolean | Auto-create matching O-entry on `create_project`. Default: false. |
+
+## Behavior
+
+**Auto-reconcile:** On every `load_project`, missing schema sections are automatically added as empty L2 nodes. Extra sections not in the schema are kept (loaded at depth 1).
+
+**No schema defined:** Falls back to hardcoded R0009 behavior and `loadProjectExpand` settings.
+
+## Legacy: load_project display (pre-v6.3.0)
+
+Only used when no `schemas` entry exists for the prefix. Controls which P-entry sections are expanded:
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `loadProjectExpand.withBody` | `[1]` | L2 section seq numbers where L3 children show title + body content. Default: `.1 Overview` — shows full architecture/state/goals detail. |
+| `loadProjectExpand.withChildren` | `[6, 8]` | L2 section seq numbers where all L3 children are listed as titles. Default: `.6 Bugs`, `.8 Open Tasks` — all items visible at a glance. |
+
+Sections not in either list show L3 titles only in compact mode.

--- a/skills/hmem-config/references/SYNC-TROUBLESHOOTING.md
+++ b/skills/hmem-config/references/SYNC-TROUBLESHOOTING.md
@@ -1,0 +1,29 @@
+# Sync Troubleshooting
+
+## Common issues
+
+| Problem | Fix |
+|---------|-----|
+| "Config not found" | Run `npx hmem-sync connect` |
+| 401 Token verification failed | Passphrase has special chars — set `HMEM_SYNC_PASSPHRASE` in .mcp.json env |
+| 0 entries after pull | `HMEM_PATH` filename must match between devices |
+| Update | `npm update -g hmem-sync` (always global, never inside a project) |
+
+## Installation
+
+If hmem-sync is not installed, it can be set up with:
+
+```bash
+npm install -g hmem-sync
+npx hmem-sync connect
+```
+
+hmem-sync enables zero-knowledge encrypted cross-device sync (AES-256-GCM, server sees only opaque blobs).
+
+## Status check
+
+When hmem-sync is installed (`which hmem-sync`), run `npx hmem-sync status` to verify:
+- Server URL
+- User ID
+- Last push/pull timestamps
+- Whether `HMEM_SYNC_PASSPHRASE` is set in `.mcp.json` (needed for auto-sync)

--- a/skills/hmem-config/references/WINDOWS-HOOKS.md
+++ b/skills/hmem-config/references/WINDOWS-HOOKS.md
@@ -1,0 +1,76 @@
+# Hook Configuration on Windows (REQUIRED)
+
+On Windows, hook execution is fragile out of the box. Two issues bite every new user:
+
+**1. Git Bash routing** — On systems with Git for Windows installed, Claude Code may route hook commands through Git Bash (`bash.exe`). Its MSYS2 runtime crashes transiently with `add_item ("\??\C:\Program Files\Git", "/", ...) failed, errno 1` during cygheap init, killing the hook **before the command is even parsed**. Symptom: `UserPromptSubmit hook error` or `Stop hook error` with a bash.exe stacktrace.
+
+**2. Unix inline env-var syntax** — Commands like `HMEM_PATH=C:/... node ...` work in bash but break in cmd.exe and PowerShell. Symptom: `"HMEM_PATH" is not recognized as a command`.
+
+**The fix for Windows users (apply to every hook + statusLine):**
+
+```json
+{
+  "env": {
+    "HMEM_PATH": "C:/Users/<you>/.hmem/Agents/<AGENT>/<AGENT>.hmem"
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js hook-startup",
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js log-exchange",
+            "shell": "powershell"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js context-inject",
+            "shell": "powershell"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js statusline",
+    "shell": "powershell"
+  }
+}
+```
+
+Two things to notice:
+- `"shell": "powershell"` on **every** hook command and on statusLine — forces native PowerShell, bypasses Git Bash entirely.
+- `HMEM_PATH` lives in the top-level `env` block, **not** inline in the command. Claude Code inherits the env block to every hook subprocess, regardless of shell.
+
+**Never use inline env-var syntax in hook commands on Windows.** `VAR=value command` is bash-only syntax and will silently break under cmd.exe or PowerShell.
+
+## Troubleshooting matrix
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `UserPromptSubmit hook error` (no stacktrace) | Inline `VAR=value` in command + cmd.exe parses it as a command name | Move env vars to `env` block, remove inline prefix |
+| `bash.exe: *** fatal error - add_item ... errno 1` | Git Bash MSYS2 runtime crashing at startup | Add `"shell": "powershell"` to every hook command |
+| Hooks silently do nothing (no errors) | Wrong shell interpreting the command, or project not active for session logging | Verify `"shell": "powershell"`, call `load_project(id="P00XX")` every session |
+
+**Note on `load_project` per-session:** The `active` flag on a P-entry persists in the database, but the "currently active project for session logging" is a per-session attribute. After every Claude Code restart, the agent must call `load_project(id="P00XX")` again, or exchanges will be logged to O0000 (no-project fallback) instead of the project's O-entry. Consider adding this to your project briefing or session-start routine.

--- a/skills/hmem-read/SKILL.md
+++ b/skills/hmem-read/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: hmem-read
-description: >
-  Load long-term memory from hmem. Use when:
-  - User types /hmem-read or says "load memory", "check your memory", "what do you remember",
-    "show me the project", "continue where we left off", "was weißt du über..."
-  - Starting work and you have no L1 summaries in context yet
-  - After /compact or context reset, to reload knowledge
-  - Before any significant work to anchor yourself with prior context
-  - User asks about a specific project, error, or topic visible in L1 summaries
-  - User says "pick up where we left off", "what were we working on", "resume",
-    "Woran haben wir gearbeitet", "Was war der letzte Stand"
-  Calls read_memory() or load_project() immediately. Also covers all read_memory query
-  patterns: search, prefix filter, context_for, stale detection, find_related,
-  memory_stats, memory_health.
+description: "Load long-term memory from hmem. Use when: user types /hmem-read or says 'load memory', 'check your memory', 'what do you remember', 'show me the project', 'continue where we left off', 'was weisst du ueber...'; starting work with no L1 summaries in context; after /compact or context reset to reload knowledge; before significant work to anchor with prior context; user asks about a specific project, error, or topic visible in L1 summaries; user says 'pick up where we left off', 'resume', 'Woran haben wir gearbeitet'. Calls read_memory() or load_project() immediately. Also covers search, prefix filter, context_for, stale detection, find_related, memory_stats, memory_health."
 ---
 
 # Load Memory — Choose Your Path
@@ -25,8 +13,6 @@ If `read_memory` is not available, tell the user:
 
 **Announcements:** If `read_memory` or `hmem-sync pull` shows urgent announcements
 (yellow warnings at the top), act on them **immediately** before doing anything else.
-These are broadcast messages from the user or another device — typically config changes,
-server migrations, or breaking updates that must be handled first.
 
 ---
 
@@ -34,59 +20,45 @@ server migrations, or breaking updates that must be handled first.
 
 Use `load_project` as the single entry point. It activates the project, returns the full
 briefing (L2 content + L3 titles), and shows recent O-entries with full L4/L5 user/agent
-exchanges — so you see exactly what happened in previous sessions, not just titles.
+exchanges.
 
-- **User mentioned a project** → load it directly:
+- **User mentioned a project** — load it directly:
   ```
   load_project(id="P0037")
   ```
-  This replaces the old pattern of `update_memory(active=true)` + `read_memory()`.
-  One call gives you everything: project structure, open tasks, and recent session history.
 
-- **Unclear which project** → list projects first, then load:
+- **Unclear which project** — list projects first, then load:
   ```
   read_memory(titles_only=true, prefix="P")   # ~200 tokens overview
   ```
   Then ask the user or pick the most relevant one, and call `load_project(id="P00XX")`.
 
-- **New project** → create it first, then load:
+- **New project** — create it first, then load:
   ```
-  write_memory(prefix="P", content="New project: ...")   # → P00XX
+  write_memory(prefix="P", content="New project: ...")   # creates P00XX
   load_project(id="P00XX")
   ```
 
-- **No specific project** → load everything:
+- **No specific project** — load everything:
   ```
   read_memory()   # full bulk read, all projects
   ```
 
-### What load_project returns
+### What load_project Returns
 
-The response includes:
 - **L2 content + L3 titles** — the complete project briefing (~700 tokens)
 - **Recent O-entries with full exchanges** — configurable via `recentOEntries` in config
-  (default: 10). Each O-entry contains the actual L4/L5 user/agent messages, not just
-  summaries. This is your continuity — read them to understand where the last session
-  left off.
-
-### Why load_project over read_memory
-
-`read_memory()` shows a cross-project overview optimized for breadth. `load_project`
-goes deep on one project — it activates it, filters related entries, and includes session
-history. Use `load_project` when you know which project to work on; use `read_memory`
-when you need orientation across all projects.
+  (default: 10). Each O-entry contains the actual L4/L5 user/agent messages.
 
 ## Path B: After Context Compression (/compact)
 
-You still have the recent conversation — you do not need the newest entries again.
-Load the long-term knowledge that was lost during compression:
+You still have the recent conversation — load the long-term knowledge lost during compression:
 
 ```
 read_memory(mode="essentials")
 ```
 
 Essentials mode prioritizes favorites, most-accessed, and pinned entries over newest.
-This is your "recover what matters" call — rules, decisions, error patterns, key references.
 
 For a specific project's full context:
 ```
@@ -95,14 +67,11 @@ read_memory(context_for="P0029")
 
 ## Path C: User Asks About a Specific Topic
 
-When the user asks about something visible in your L1 summaries:
+When the user asks about something visible in L1 summaries:
 
 ```
-# "Was weißt du über das hmem Projekt?"
-read_memory(context_for="P0029")
-
-# "Tell me about that Heimdall error"
-read_memory(context_for="E0090")
+read_memory(context_for="P0029")     # project context + all related entries
+read_memory(context_for="E0090")     # error context + related
 ```
 
 `context_for` loads the entry expanded + all related entries (via links and weighted tag
@@ -117,11 +86,11 @@ read_memory(context_for="P0029", min_tag_score=7)   # stricter — only strong m
 ## Bulk Read Design
 
 `read_memory()` shows **current context** — newest entries, most-accessed favorites, open
-tasks. It is not a full dump. Older entries with low access_count are intentionally omitted.
+tasks. Not a full dump. Older entries with low access_count are intentionally omitted.
 
-**Expanded entries** (newest, most-accessed, favorites): show L2 children + links.
-**Non-expanded entries**: latest child + `[+N more → ID]` hint.
-**Active-prefix filtering**: entries in active projects get full expansion, others title-only.
+- **Expanded entries** (newest, most-accessed, favorites): show L2 children + links
+- **Non-expanded entries**: latest child + `[+N more -> ID]` hint
+- **Active-prefix filtering**: entries in active projects get full expansion, others title-only
 
 **For older or broader knowledge:**
 
@@ -131,25 +100,7 @@ read_memory(search="SQLite corruption")      # semantic search
 read_memory(tag="#sqlite")                   # hashtag filter
 ```
 
-**Tags are hidden by default** — use `read_memory(curator=true)` to see hashtags on entries.
-
-Repeated bulk reads without a goal yield little new information after 3-4 iterations — use
-targeted search or a prefix overview instead.
-
----
-
-## Title vs. Body (v5.1+)
-
-Every node has a **title** (short navigation label) and an optional **body** (detail shown on drill-down). This affects what you see in different read modes:
-
-| Mode | Shows |
-|------|-------|
-| `titles_only=true` | Title only — compact table of contents |
-| Default (by ID) | Title + body for requested node, children as title-only |
-| `expand=true` | Title + body recursively for all nodes |
-| Bulk reads | Title only for L1, expanded entries show L2 titles |
-
-Entries with a blank line between title and body have explicit title/body separation. Older entries without separation show auto-extracted titles (~50 chars) — the full text is still accessible on drill-down.
+Tags are hidden by default — use `read_memory(curator=true)` to see hashtags on entries.
 
 ---
 
@@ -160,9 +111,8 @@ After the initial load, drill deeper with these patterns:
 ```
 read_memory(prefix="E")           # only errors
 read_memory(store="company")      # shared company knowledge
-read_memory(id="E0042")           # expand root → shows L2 children
-read_memory(id="E0042.2")         # expand L2 → shows L3 children
-read_memory(id="E0042.2.1")       # expand further (rarely needed)
+read_memory(id="E0042")           # expand root -> shows L2 children
+read_memory(id="E0042.2")         # expand L2 -> shows L3 children
 ```
 
 **Compact table of contents:**
@@ -184,20 +134,6 @@ For L5 detail, drill into a specific node ID instead of using depth.
 
 ---
 
-## Time-Based Search
-
-Find entries created around a specific time or near another entry:
-
-```
-read_memory(time="14:30")                        # ±2h window around 14:30 today
-read_memory(time="14:30", date="2026-02-20")     # specific date + time
-read_memory(time="14:30", period="-1h")           # custom window: only 1h before
-read_memory(time_around="P0001")                  # entries created near P0001
-read_memory(time_around="P0001", period="+2h")    # only after P0001
-```
-
----
-
 ## Search
 
 ```
@@ -205,17 +141,17 @@ search_memory(query="Node.js startup crash")
 search_memory(query="auth token", scope="memories")
 ```
 
+For time-based search patterns, see [references/TIME-SEARCH.md](references/TIME-SEARCH.md).
+
 ---
 
 ## Original Context History (O-prefix)
 
 O-entries store raw session context with progressive summarization. They are created
-**automatically** by the Stop hook — every user/agent exchange is recorded as an O-entry
-without manual intervention. When you switch projects, a new O-entry is started
-automatically (project-based O-entries).
+**automatically** by the Stop hook — every user/agent exchange is recorded without manual
+intervention. When projects are switched, a new O-entry starts automatically.
 
-O-entries are hidden from bulk reads but searchable. Use them when you need the original
-reasoning behind a decision or the full conversation that led to an entry:
+O-entries are hidden from bulk reads but searchable:
 
 ```
 read_memory(prefix="O")                                    # browse recent context
@@ -226,91 +162,24 @@ read_memory(id="O0042", expand=true)                       # drill into specific
 O-entries are linked to curated entries (P/L/D/E) via tags, so `context_for` will
 surface relevant O-entries when their tags match.
 
-**v5 checkpoint integration:** When `checkpointMode` is set to `"auto"`, a Haiku subagent
-reads recent O-entry exchanges at configurable intervals and automatically extracts
-L/D/E entries + writes a rolling checkpoint summary (`[CP]` node tagged `#checkpoint-summary`).
+**v5 checkpoint integration:** When `checkpointMode` is `"auto"`, a Haiku subagent reads
+recent O-entry exchanges at configurable intervals and automatically extracts L/D/E entries
++ writes a rolling checkpoint summary (`[CP]` node tagged `#checkpoint-summary`).
 
 **What `load_project` shows:** For the latest O-entry, it displays:
 1. The most recent checkpoint summary (if available)
 2. Only raw exchanges AFTER the summary (minimum 5 exchanges guaranteed)
 3. Skill-dialog exchanges (brainstorming, TDD, etc.) are filtered out automatically
 
-This keeps `load_project` compact even for long sessions. To see the full unfiltered
-history, use `read_memory(id="O0042", expand=true)`.
-
 The `recentOEntries` config parameter (default: 10) controls how many recent O-entries
 `load_project` includes.
-
----
-
-## Show All Obsolete Entries
-
-By default, bulk reads hide most obsolete entries (top 3 by access count shown). To see all:
-
-```
-read_memory(show_obsolete=true)
-```
-
----
-
-## Stale Detection
-
-Find entries not accessed in a while — useful for curation:
-
-```
-read_memory(stale_days=30)                # sorted oldest-access first
-read_memory(stale_days=60, prefix="L")    # only stale lessons
-```
-
----
-
-## Memory Stats
-
-Quick overview of your memory health:
-
-```
-memory_stats()                    # personal store
-memory_stats(store="company")     # company store
-```
-
-Output includes: total entries by prefix, total nodes, favorites count, pinned count,
-unique hashtags, stale count (>30d), oldest entry, and top 5 most-accessed entries.
-
----
-
-## Find Related
-
-Find entries similar to a given entry via FTS5 keyword matching — spots potential
-duplicates or thematic connections:
-
-```
-find_related(id="P0029")            # up to 5 similar entries
-find_related(id="L0042", limit=10)
-```
-
-Returns title-only list with overlapping keywords (different from `relatedEntries` in
-ID reads which uses shared tags).
-
----
-
-## Memory Health Audit
-
-Check memory for structural issues before/after curation:
-
-```
-memory_health()                    # personal store
-memory_health(store="company")
-```
-
-Checks: broken links, orphaned entries, stale favorites/pinned, broken obsolete chains,
-tag orphans.
 
 ---
 
 ## Adapt Communication to User Skill Level
 
 After loading memory, check H-prefix entries for **User Skill Assessments** (e.g. H0010).
-These contain 1-10 scores per subtopic — adapt your language accordingly:
+These contain 1-10 scores per subtopic — adapt language accordingly:
 
 - **1-4**: Explain concepts, avoid jargon, use analogies
 - **5-6**: Brief explanations, some jargon OK
@@ -324,65 +193,15 @@ If no skill assessment exists yet, create one based on the user's vocabulary and
 
 ## After Loading — Proactive Curation
 
-Your memory is your brain. If something is wrong, stale, or noisy — fix it NOW, don't list
-problems for later. This applies after `load_project` AND after `read_memory`.
+Memory is the agent's brain. If something is wrong, stale, or noisy — fix it NOW.
+This applies after `load_project` AND after `read_memory`.
 
-### Scan the load_project output
+Scan load_project output for resolved bugs, stale info, duplicates, and misplaced entries.
+Fix immediately before responding to the user.
 
-Every time you receive a `load_project` response, scan it for issues and fix them
-immediately — before responding to the user. The load_project output IS the briefing
-that every future session gets. If it contains noise, every future session starts with
-noise. Treat it like your own resume: if something doesn't belong, remove it.
+For detailed curation guidance and move_nodes usage, see [references/CURATION.md](references/CURATION.md).
 
-**What to look for and how to fix it:**
-
-| Problem | Example | Action |
-|---------|---------|--------|
-| Resolved/done bugs | `.6.2 E0101: O-entry root title never updated` (fixed months ago) | `update_memory(id="P0048.6.2", content="...", irrelevant=true)` |
-| Old protocol entries | `.7.32 - windowsHide: true on all child_process spawns` (fragment, not a session) | `update_memory(id="P0048.7.32", content="...", irrelevant=true)` |
-| Stale version info | Overview says "v5.3.1" but current is v6.0.0 | `update_memory(id="P0048.1.1", content="Current state: v6.0.0 on npm...")` |
-| Duplicate sections | `.10 Bugs (duplicate of .6)` | `update_memory(id="P0048.10", content="...", irrelevant=true)` |
-| Completed open tasks | `.8.2 ✓ DONE: O-Entry Session History Injection` | Should be auto-filtered; if not, mark irrelevant |
-| Wrong project's exchanges | O-entry exchanges from P0052 appearing in P0048 | Use `move_nodes` (see below) |
-| Stale env/config references | Still references `HMEM_PROJECT_DIR` instead of `HMEM_PATH` | Update the node content |
-
-Use `update_many` when marking multiple entries irrelevant in one go:
-```
-update_many(ids=["P0048.7.32", "P0048.6.2", "P0048.6.5"], irrelevant=true)
-```
-
-### Fix misplaced O-entries with move_nodes
-
-When exchanges or session nodes land in the wrong O-entry (e.g. project confusion during
-a session), move them to the correct location:
-
-```
-move_nodes(source_ids=["O0048.3.1.5", "O0048.3.1.6"], target_parent="O0052.1.1")
-```
-
-This preserves the exchange content while fixing the tree structure. Don't delete
-misplaced entries — move them to where they belong.
-
-### Scan bulk read output (read_memory)
-
-After any `read_memory()` call, scan for:
-
-- **Wrong facts** → write correction first, then mark obsolete with `[✓ID]`:
-  ```
-  write_memory(prefix="E", content="Correct fix is...") → E0076
-  update_memory(id="E0042", content="Wrong — see [✓E0076]", obsolete=true)
-  ```
-- **Noise/irrelevant** → `update_memory(id="T0005", content="...", irrelevant=true)`
-- **Important discoveries** → `update_memory(id="S0001", content="...", favorite=true)`
-
-### When NOT to curate
-
-- Don't curate after every single `read_memory` call — only on the first bulk read
-  of a session and after `load_project`
-- Don't curate during time-critical tasks (the user is waiting for a bug fix, not curation)
-- Don't mark entries irrelevant if you're unsure — ask the user first
-
-For a thorough deep-clean, use the `/hmem-self-curate` skill.
+For memory health audits, stats, stale detection, and find_related, see [references/HEALTH-AUDIT.md](references/HEALTH-AUDIT.md).
 
 ---
 
@@ -397,7 +216,7 @@ For a thorough deep-clean, use the `/hmem-self-curate` skill.
 | Load everything without purpose | Check L1 first, then expand selectively |
 | Read .hmem file directly | Always use MCP tools — it is a SQLite binary |
 | Just display this skill text | **Call a read_memory or load_project variant immediately** |
-| `update_memory(id="X", obsolete=true)` without `[✓ID]` | Write correction first, then mark obsolete with `[✓ID]` tag |
+| `update_memory(id="X", obsolete=true)` without correction | Write correction first, then mark obsolete with `[ID]` tag |
 | Repeated `read_memory()` to find old entries | `read_memory(titles_only=true, prefix="L")` or `read_memory(search="...")` |
 | Listing noise without fixing it | Fix it NOW: `update_memory(id, content, irrelevant=true)` |
 | Deleting misplaced O-entries | Move them: `move_nodes(source_ids=[...], target_parent="O00XX.Y")` |

--- a/skills/hmem-read/references/CURATION.md
+++ b/skills/hmem-read/references/CURATION.md
@@ -1,0 +1,55 @@
+# After Loading — Proactive Curation Reference
+
+Memory is the agent's brain. If something is wrong, stale, or noisy — fix it NOW, don't list problems for later. This applies after `load_project` AND after `read_memory`.
+
+## Scan load_project Output
+
+Every time a `load_project` response is received, scan it for issues and fix them immediately — before responding to the user. The load_project output IS the briefing that every future session gets. If it contains noise, every future session starts with noise.
+
+### What to Look For and How to Fix It
+
+| Problem | Example | Action |
+|---------|---------|--------|
+| Resolved/done bugs | `.6.2 E0101: O-entry root title never updated` (fixed months ago) | `update_memory(id="P0048.6.2", content="...", irrelevant=true)` |
+| Old protocol entries | `.7.32 - windowsHide: true on all child_process spawns` (fragment) | `update_memory(id="P0048.7.32", content="...", irrelevant=true)` |
+| Stale version info | Overview says "v5.3.1" but current is v6.0.0 | `update_memory(id="P0048.1.1", content="Current state: v6.0.0 on npm...")` |
+| Duplicate sections | `.10 Bugs (duplicate of .6)` | `update_memory(id="P0048.10", content="...", irrelevant=true)` |
+| Completed open tasks | `.8.2 DONE: O-Entry Session History Injection` | Should be auto-filtered; if not, mark irrelevant |
+| Wrong project's exchanges | O-entry exchanges from P0052 appearing in P0048 | Use `move_nodes` (see below) |
+| Stale env/config references | Still references `HMEM_PROJECT_DIR` instead of `HMEM_PATH` | Update the node content |
+
+Use `update_many` when marking multiple entries irrelevant in one go:
+
+```
+update_many(ids=["P0048.7.32", "P0048.6.2", "P0048.6.5"], irrelevant=true)
+```
+
+## Fix Misplaced O-Entries with move_nodes
+
+When exchanges or session nodes land in the wrong O-entry (e.g. project confusion during a session), move them to the correct location:
+
+```
+move_nodes(source_ids=["O0048.3.1.5", "O0048.3.1.6"], target_parent="O0052.1.1")
+```
+
+This preserves the exchange content while fixing the tree structure. Don't delete misplaced entries — move them to where they belong.
+
+## Scan Bulk Read Output (read_memory)
+
+After any `read_memory()` call, scan for:
+
+- **Wrong facts** — write correction first, then mark obsolete with `[ID]`:
+  ```
+  write_memory(prefix="E", content="Correct fix is...") -> E0076
+  update_memory(id="E0042", content="Wrong — see [E0076]", obsolete=true)
+  ```
+- **Noise/irrelevant** — `update_memory(id="T0005", content="...", irrelevant=true)`
+- **Important discoveries** — `update_memory(id="S0001", content="...", favorite=true)`
+
+## When NOT to Curate
+
+- Don't curate after every single `read_memory` call — only on the first bulk read of a session and after `load_project`
+- Don't curate during time-critical tasks (the user is waiting for a bug fix, not curation)
+- Don't mark entries irrelevant if unsure — ask the user first
+
+For a thorough deep-clean, use the `/hmem-self-curate` skill.

--- a/skills/hmem-read/references/HEALTH-AUDIT.md
+++ b/skills/hmem-read/references/HEALTH-AUDIT.md
@@ -1,0 +1,51 @@
+# Memory Health, Stats & Related Entries Reference
+
+## Memory Health Audit
+
+Check memory for structural issues before/after curation:
+
+```
+memory_health()                    # personal store
+memory_health(store="company")
+```
+
+Checks: broken links, orphaned entries, stale favorites/pinned, broken obsolete chains, tag orphans.
+
+## Memory Stats
+
+Quick overview of memory health:
+
+```
+memory_stats()                    # personal store
+memory_stats(store="company")     # company store
+```
+
+Output includes: total entries by prefix, total nodes, favorites count, pinned count, unique hashtags, stale count (>30d), oldest entry, and top 5 most-accessed entries.
+
+## Find Related
+
+Find entries similar to a given entry via FTS5 keyword matching — spots potential duplicates or thematic connections:
+
+```
+find_related(id="P0029")            # up to 5 similar entries
+find_related(id="L0042", limit=10)
+```
+
+Returns title-only list with overlapping keywords (different from `relatedEntries` in ID reads which uses shared tags).
+
+## Stale Detection
+
+Find entries not accessed in a while — useful for curation:
+
+```
+read_memory(stale_days=30)                # sorted oldest-access first
+read_memory(stale_days=60, prefix="L")    # only stale lessons
+```
+
+## Show All Obsolete Entries
+
+By default, bulk reads hide most obsolete entries (top 3 by access count shown). To see all:
+
+```
+read_memory(show_obsolete=true)
+```

--- a/skills/hmem-read/references/TIME-SEARCH.md
+++ b/skills/hmem-read/references/TIME-SEARCH.md
@@ -1,0 +1,23 @@
+# Time-Based Search Reference
+
+Find entries created around a specific time or near another entry.
+
+## Basic Time Queries
+
+```
+read_memory(time="14:30")                        # +/-2h window around 14:30 today
+read_memory(time="14:30", date="2026-02-20")     # specific date + time
+```
+
+## Custom Windows
+
+```
+read_memory(time="14:30", period="-1h")           # only 1h before 14:30
+```
+
+## Relative to Another Entry
+
+```
+read_memory(time_around="P0001")                  # entries created near P0001
+read_memory(time_around="P0001", period="+2h")    # only entries after P0001
+```

--- a/skills/hmem-setup/SKILL.md
+++ b/skills/hmem-setup/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: hmem-setup
-description: Interactive setup guide for hmem. Run this skill to install and configure
-  the hmem MCP server — installs dependencies, configures .mcp.json, deploys skill
-  files, and registers auto-memory hooks for Claude Code, Gemini CLI, or OpenCode.
+description: "Set up and configure the hmem memory system. Run this skill to install hmem, initialize the MCP server, deploy skill files, and register auto-memory hooks for Claude Code, Gemini CLI, or OpenCode. Covers first-time setup, manual installation, and post-setup verification."
 ---
 
 # hmem Setup
@@ -23,7 +21,7 @@ hmem init
 4. Writes `.mcp.json` with the correct paths for each detected tool
 5. Adds session-start instructions to the tool's config file (CLAUDE.md, GEMINI.md, etc.)
 6. Creates `hmem.config.json` with sensible defaults
-7. Installs all 4 auto-memory hooks (Claude Code only — see Hook Reference below)
+7. Installs all 4 auto-memory hooks (Claude Code only — see [Hook Reference](references/HOOKS.md))
 8. Copies skill files (slash commands) to the tool's skill directory
 
 After `hmem init`, install the slash-command skills:
@@ -42,107 +40,14 @@ hmem init --global --tools claude-code --dir ~/.hmem --no-example
 
 ---
 
-## Hook Reference (Claude Code)
+## Hooks and Configuration
 
-`hmem init` registers 4 hooks in `~/.claude/settings.json`. Each hook is a bash script in `~/.claude/hooks/`.
+For detailed reference material on hooks and configuration options, see:
 
-### 1. UserPromptSubmit — memory load + checkpoint reminder
+- **[Hook Reference](references/HOOKS.md)** — describes the 4 Claude Code hooks registered by `hmem init` (UserPromptSubmit, Stop, SessionStart)
+- **[Configuration Reference](references/CONFIG.md)** — full `hmem.config.json` schema, defaults, and bulk-read tuning parameters
 
-Script: `~/.claude/hooks/hmem-startup.sh`
-
-- **First message**: injects `additionalContext` telling the agent to call `read_memory()` silently.
-- **Every Nth message** (N = `checkpointInterval`, default 20): injects a checkpoint reminder.
-  - `checkpointMode: "remind"` — adds an `additionalContext` nudge; the agent decides what to save.
-  - `checkpointMode: "auto"` — checkpoint is handled by the Stop hook instead (no reminder injected).
-- Subagents (messages with `parentUuid`) are skipped.
-- Uses a per-session counter file at `/tmp/claude-hmem-counter-{SESSION_ID}`.
-
-### 2. Stop (async) — exchange logging + checkpoint
-
-Script: `~/.claude/hooks/hmem-log-exchange.sh`
-
-- Runs asynchronously after every agent response (timeout: 10s).
-- Pipes the Stop hook JSON (containing `transcript_path` and `last_assistant_message`) to `hmem log-exchange`.
-- `hmem log-exchange` reads the last user message from the JSONL transcript, combines it with the agent response, and appends both to the currently active O-entry (session history).
-- If no active O-entry exists, one is created automatically.
-- Every N exchanges (configurable via `checkpointInterval`, default 20), triggers a checkpoint:
-  - **auto mode**: Spawns `hmem checkpoint` in background — Haiku subagent with MCP tools that:
-    - Titles each exchange with a descriptive summary (max 50 chars)
-    - Writes L/D/E entries for non-obvious insights
-    - Updates P-entry (protocol, bugs, open tasks, overview, codebase)
-    - Writes a checkpoint summary for context re-injection
-    - Verifies project relevance and fixes links
-  - **remind mode**: Injects a reminder for the main agent to save knowledge manually
-- Checks transcript file size and writes a warning flag when context exceeds `contextTokenThreshold` (default 100k tokens).
-
-### 3. SessionStart[clear] — context re-injection
-
-Script: `~/.claude/hooks/hmem-context-inject.sh`
-
-- Fires only after `/clear` (matcher: `"clear"`).
-- Pipes session JSON to `hmem context-inject`, which outputs `additionalContext` containing:
-  - Last 20 user/assistant messages from the pre-clear transcript
-  - Active project briefing (title + overview)
-  - Recent O-entries (session logs) linked to the project
-  - R-entries (rules)
-- Keeps the agent oriented after a context reset without a full `read_memory()` call.
-
----
-
-## Configuration Reference
-
-Place `hmem.config.json` in your memory directory (the path you chose during `hmem init`). All keys are optional — defaults are applied for anything missing.
-
-```json
-{
-  "memory": {
-    "maxCharsPerLevel": [200, 2500, 10000, 25000, 50000],
-    "maxDepth": 5,
-    "defaultReadLimit": 100,
-    "maxTitleChars": 50,
-    "checkpointInterval": 20,
-    "checkpointMode": "remind",
-    "recentOEntries": 10,
-    "contextTokenThreshold": 100000,
-    "bulkReadV2": {
-      "topAccessCount": 3,
-      "topNewestCount": 5,
-      "topObsoleteCount": 3,
-      "topSubnodeCount": 3,
-      "newestPercent": 20,
-      "newestMin": 5,
-      "newestMax": 15,
-      "accessPercent": 10,
-      "accessMin": 3,
-      "accessMax": 8
-    }
-  }
-}
-```
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `maxCharsPerLevel` | `number[]` | `[200,2500,10000,25000,50000]` | Character limit per tree depth (L1..L5). Alternative: set `maxL1Chars` + `maxLnChars` and levels are interpolated linearly. |
-| `maxDepth` | `number` | `5` | Max tree depth (1 = L1 only, 5 = full). |
-| `defaultReadLimit` | `number` | `100` | Max entries returned by a default `read_memory()`. |
-| `maxTitleChars` | `number` | `50` | Max characters for auto-extracted titles. |
-| `checkpointInterval` | `number` | `20` | Messages between checkpoint reminders. Set 0 to disable. |
-| `checkpointMode` | `"remind"` or `"auto"` | `"remind"` | `"remind"` = inject a save-reminder via `additionalContext`. `"auto"` = spawn a Haiku subagent that saves directly (no user interaction). |
-| `recentOEntries` | `number` | `10` | Number of recent O-entries (session logs) injected at startup and on `load_project`. Set 0 to disable. |
-| `contextTokenThreshold` | `number` | `100000` | Token threshold for context-clear recommendation. When cumulative hmem output exceeds this, the agent is told to flush + `/clear`. Set 0 to disable. |
-
-**Bulk-read tuning** (`bulkReadV2`): controls which entries get expanded (all L2 children shown) in a default `read_memory()` call. Per prefix category, the top N newest + top M most-accessed entries are expanded. Favorites are always expanded.
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `topAccessCount` | `3` | Fixed fallback: top-accessed entries to expand. |
-| `topNewestCount` | `5` | Fixed fallback: newest entries to expand. |
-| `topObsoleteCount` | `3` | Obsolete entries to keep visible. |
-| `topSubnodeCount` | `3` | Entries with most sub-nodes to always expand. |
-| `newestPercent` | `20` | Percentage-based selection (overrides `topNewestCount`). |
-| `newestMin` / `newestMax` | `5` / `15` | Clamp for percentage-based newest selection. |
-| `accessPercent` | `10` | Percentage-based selection (overrides `topAccessCount`). |
-| `accessMin` / `accessMax` | `3` / `8` | Clamp for percentage-based access selection. |
+Key configuration defaults: `checkpointInterval: 20`, `checkpointMode: "remind"`, `contextTokenThreshold: 100000`. Place `hmem.config.json` in the memory directory chosen during `hmem init`.
 
 ---
 

--- a/skills/hmem-setup/references/CONFIG.md
+++ b/skills/hmem-setup/references/CONFIG.md
@@ -1,0 +1,58 @@
+# Configuration Reference
+
+Place `hmem.config.json` in your memory directory (the path you chose during `hmem init`). All keys are optional — defaults are applied for anything missing.
+
+```json
+{
+  "memory": {
+    "maxCharsPerLevel": [200, 2500, 10000, 25000, 50000],
+    "maxDepth": 5,
+    "defaultReadLimit": 100,
+    "maxTitleChars": 50,
+    "checkpointInterval": 20,
+    "checkpointMode": "remind",
+    "recentOEntries": 10,
+    "contextTokenThreshold": 100000,
+    "bulkReadV2": {
+      "topAccessCount": 3,
+      "topNewestCount": 5,
+      "topObsoleteCount": 3,
+      "topSubnodeCount": 3,
+      "newestPercent": 20,
+      "newestMin": 5,
+      "newestMax": 15,
+      "accessPercent": 10,
+      "accessMin": 3,
+      "accessMax": 8
+    }
+  }
+}
+```
+
+## Core Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `maxCharsPerLevel` | `number[]` | `[200,2500,10000,25000,50000]` | Character limit per tree depth (L1..L5). Alternative: set `maxL1Chars` + `maxLnChars` and levels are interpolated linearly. |
+| `maxDepth` | `number` | `5` | Max tree depth (1 = L1 only, 5 = full). |
+| `defaultReadLimit` | `number` | `100` | Max entries returned by a default `read_memory()`. |
+| `maxTitleChars` | `number` | `50` | Max characters for auto-extracted titles. |
+| `checkpointInterval` | `number` | `20` | Messages between checkpoint reminders. Set 0 to disable. |
+| `checkpointMode` | `"remind"` or `"auto"` | `"remind"` | `"remind"` = inject a save-reminder via `additionalContext`. `"auto"` = spawn a Haiku subagent that saves directly (no user interaction). |
+| `recentOEntries` | `number` | `10` | Number of recent O-entries (session logs) injected at startup and on `load_project`. Set 0 to disable. |
+| `contextTokenThreshold` | `number` | `100000` | Token threshold for context-clear recommendation. When cumulative hmem output exceeds this, the agent is told to flush + `/clear`. Set 0 to disable. |
+
+## Bulk-Read Tuning (`bulkReadV2`)
+
+Controls which entries get expanded (all L2 children shown) in a default `read_memory()` call. Per prefix category, the top N newest + top M most-accessed entries are expanded. Favorites are always expanded.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `topAccessCount` | `3` | Fixed fallback: top-accessed entries to expand. |
+| `topNewestCount` | `5` | Fixed fallback: newest entries to expand. |
+| `topObsoleteCount` | `3` | Obsolete entries to keep visible. |
+| `topSubnodeCount` | `3` | Entries with most sub-nodes to always expand. |
+| `newestPercent` | `20` | Percentage-based selection (overrides `topNewestCount`). |
+| `newestMin` / `newestMax` | `5` / `15` | Clamp for percentage-based newest selection. |
+| `accessPercent` | `10` | Percentage-based selection (overrides `topAccessCount`). |
+| `accessMin` / `accessMax` | `3` / `8` | Clamp for percentage-based access selection. |

--- a/skills/hmem-setup/references/HOOKS.md
+++ b/skills/hmem-setup/references/HOOKS.md
@@ -1,0 +1,44 @@
+# Hook Reference (Claude Code)
+
+`hmem init` registers 4 hooks in `~/.claude/settings.json`. Each hook is a bash script in `~/.claude/hooks/`.
+
+## 1. UserPromptSubmit — memory load + checkpoint reminder
+
+Script: `~/.claude/hooks/hmem-startup.sh`
+
+- **First message**: injects `additionalContext` telling the agent to call `read_memory()` silently.
+- **Every Nth message** (N = `checkpointInterval`, default 20): injects a checkpoint reminder.
+  - `checkpointMode: "remind"` — adds an `additionalContext` nudge; the agent decides what to save.
+  - `checkpointMode: "auto"` — checkpoint is handled by the Stop hook instead (no reminder injected).
+- Subagents (messages with `parentUuid`) are skipped.
+- Uses a per-session counter file at `/tmp/claude-hmem-counter-{SESSION_ID}`.
+
+## 2. Stop (async) — exchange logging + checkpoint
+
+Script: `~/.claude/hooks/hmem-log-exchange.sh`
+
+- Runs asynchronously after every agent response (timeout: 10s).
+- Pipes the Stop hook JSON (containing `transcript_path` and `last_assistant_message`) to `hmem log-exchange`.
+- `hmem log-exchange` reads the last user message from the JSONL transcript, combines it with the agent response, and appends both to the currently active O-entry (session history).
+- If no active O-entry exists, one is created automatically.
+- Every N exchanges (configurable via `checkpointInterval`, default 20), triggers a checkpoint:
+  - **auto mode**: Spawns `hmem checkpoint` in background — Haiku subagent with MCP tools that:
+    - Titles each exchange with a descriptive summary (max 50 chars)
+    - Writes L/D/E entries for non-obvious insights
+    - Updates P-entry (protocol, bugs, open tasks, overview, codebase)
+    - Writes a checkpoint summary for context re-injection
+    - Verifies project relevance and fixes links
+  - **remind mode**: Injects a reminder for the main agent to save knowledge manually
+- Checks transcript file size and writes a warning flag when context exceeds `contextTokenThreshold` (default 100k tokens).
+
+## 3. SessionStart[clear] — context re-injection
+
+Script: `~/.claude/hooks/hmem-context-inject.sh`
+
+- Fires only after `/clear` (matcher: `"clear"`).
+- Pipes session JSON to `hmem context-inject`, which outputs `additionalContext` containing:
+  - Last 20 user/assistant messages from the pre-clear transcript
+  - Active project briefing (title + overview)
+  - Recent O-entries (session logs) linked to the project
+  - R-entries (rules)
+- Keeps the agent oriented after a context reset without a full `read_memory()` call.

--- a/skills/hmem-update/SKILL.md
+++ b/skills/hmem-update/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: hmem-update
-description: >
-  Post-update checklist for hmem-mcp and hmem-sync. Run after npm update or when
-  hmem detects a version change. Covers skill sync, entry migration, schema enforcement,
-  O-entry curation, and smoke tests. Use when the user says "update hmem", "hmem updaten",
-  or when the startup version-check detects a new version.
+description: "Post-update checklist for hmem-mcp and hmem-sync. Run after npm update or when hmem detects a version change. Covers skill sync, entry migration, schema enforcement, O-entry curation, and smoke tests. Use when the user says \"update hmem\", \"hmem updaten\", or when the startup version-check detects a new version."
 ---
 
 # /hmem-update — Post-Update Checklist
@@ -23,12 +19,7 @@ npm view hmem-mcp version         # latest on npm
 npm view hmem-mcp versions --json # all versions
 ```
 
-Read the changelog for the version range:
-```bash
-cd ~/projects/hmem && git log --oneline <old-tag>..HEAD  # if local repo exists
-```
-
-Or check GitHub releases: `gh release list -R Bumblebiber/hmem --limit 5`
+Read the changelog: `gh release list -R Bumblebiber/hmem --limit 5` or check `git log --oneline <old-tag>..HEAD` in a local repo.
 
 **If already on latest:** Tell the user and skip to Step 7 (smoke test).
 
@@ -40,14 +31,14 @@ Or check GitHub releases: `gh release list -R Bumblebiber/hmem --limit 5`
 hmem update-skills
 ```
 
-This syncs all skill files from the npm package to the local skills directory. Verify:
+Syncs all skill files from the npm package to the local skills directory. Verify:
 
 ```bash
 ls ~/.claude/skills/hmem-*/SKILL.md   # Claude Code
 ls ~/.config/gemini/skills/hmem-*/     # Gemini CLI (if applicable)
 ```
 
-Check for new skills that weren't there before — inform the user about new capabilities.
+Inform the user about any new skills.
 
 ---
 
@@ -55,279 +46,105 @@ Check for new skills that weren't there before — inform the user about new cap
 
 Hooks are critical — without them, O-entries are never logged and auto-checkpoints never fire.
 
-Check the current hook configuration. Use the platform-appropriate command:
-
-```bash
-# Linux / macOS
-cat ~/.claude/settings.json | grep -A5 hooks
-```
-
-```powershell
-# Windows (PowerShell)
-Get-Content "$env:USERPROFILE\.claude\settings.json" | Select-String -Pattern "hooks" -Context 0,5
-```
+Check hook configuration in `~/.claude/settings.json`.
 
 **Required hooks (for `checkpointMode: "auto"`):**
 - **UserPromptSubmit** — memory load + checkpoint reminder
 - **Stop** — exchange logging (`hmem log-exchange`) + O-entry title generation
 - **SessionStart[clear]** — context re-injection after `/clear`
 
-**If hooks are missing or empty (`hooks: {}`):**
-1. Inform the user: "Hooks are not configured — O-entries won't be logged and auto-checkpoints won't fire."
-2. Suggest: "Run `/hmem-config` to set up hooks, or run `hmem init` to re-initialize."
+**If hooks are missing or empty:** Inform the user and suggest `/hmem-config` or `hmem init`.
 
-**If hooks exist but reference old paths or scripts:**
-- Check that hook scripts exist and are executable
-- Verify they reference the current hmem installation path
+**If hooks reference old paths:** Verify scripts exist and point to the current installation.
 
-### Windows-specific hook checks (CRITICAL)
-
-On Windows, two specific issues break hooks. Always run these checks when updating on Windows:
-
-**Check 1 — `shell: powershell` present on every hook command?**
-
-Each object in `hooks.*.hooks` and the `statusLine` object must contain `"shell": "powershell"`. Without it, Claude Code may route the command through Git Bash, whose MSYS2 runtime crashes transiently at startup (`bash.exe: *** fatal error - add_item ... errno 1`) before the command is even parsed. Every hook then fails with a generic error.
-
-**Check 2 — No inline env-var syntax in commands?**
-
-Commands must NOT contain `VAR=value` prefixes like `HMEM_PATH=C:/... node ...`. That's bash-only syntax; cmd.exe and PowerShell interpret `HMEM_PATH=...` as the command name and fail. All env vars must live in the top-level `env` block of settings.json.
-
-**The correct Windows shape:**
-
-```json
-{
-  "env": {
-    "HMEM_PATH": "C:/Users/<you>/.hmem/Agents/<AGENT>/<AGENT>.hmem"
-  },
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js log-exchange",
-            "shell": "powershell"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-**If either check fails:** Offer to fix settings.json automatically. The fix is lossless on other platforms, so it's safe to apply even on shared configs synced across OSes. Point the user to the Windows hook section in `/hmem-config` for the full pattern (UserPromptSubmit, Stop, SessionStart, statusLine).
-
-**After fixing:** Claude Code must be restarted so the `env` block is re-loaded and hooks are re-registered with the new shell.
+**Windows users:** Two platform-specific issues commonly break hooks. See [references/WINDOWS-HOOKS.md](references/WINDOWS-HOOKS.md) for diagnosis and fix steps.
 
 ---
 
 ## Step 2c: Check load_project Display Config
 
-Since v5.1.8, `load_project` supports configurable section expansion:
-- `loadProjectExpand.withBody`: sections showing L3 title + body (default: `[1]` = Overview)
-- `loadProjectExpand.withChildren`: sections listing all L3 children as titles (default: `[6, 8]` = Bugs, Open Tasks)
+Since v5.1.8, `load_project` supports configurable section expansion via `hmem.config.json`:
 
-Check if the user has customized this in `hmem.config.json`. If not, inform them about the option:
 ```json
 { "memory": { "loadProjectExpand": { "withBody": [1], "withChildren": [6, 8] } } }
 ```
+
+- `withBody`: sections showing L3 title + body (default: `[1]` = Overview)
+- `withChildren`: sections listing all L3 children as titles (default: `[6, 8]` = Bugs, Open Tasks)
+
+Inform the user if not yet customized.
 
 ---
 
 ## Step 2d: HMEM_PATH Migration (v6.0.0+)
 
-v6.0.0 replaced `HMEM_PROJECT_DIR` + `HMEM_AGENT_ID` with a single `HMEM_PATH` env var.
+v6.0.0 replaced `HMEM_PROJECT_DIR` + `HMEM_AGENT_ID` with a single `HMEM_PATH` env var. If the user's config still references the old vars, migration is needed.
 
-**Check if migration is needed:**
-1. Look at the user's `.mcp.json` or `~/.claude.json` for hmem env vars
-2. If you see `HMEM_PROJECT_DIR` and/or `HMEM_AGENT_ID` → migration needed
-
-**Migration steps:**
-
-1. Determine the current .hmem file path:
-   - With agent ID: `{HMEM_PROJECT_DIR}/Agents/{HMEM_AGENT_ID}/{HMEM_AGENT_ID}.hmem`
-   - Without: `{HMEM_PROJECT_DIR}/memory.hmem`
-
-2. Update MCP config — replace the old env vars with `HMEM_PATH`:
-   ```json
-   {
-     "env": {
-       "HMEM_PATH": "/absolute/path/to/your/file.hmem"
-     }
-   }
-   ```
-   Remove `HMEM_PROJECT_DIR`, `HMEM_AGENT_ID`, and `HMEM_AGENT_ROLE` from the env block.
-
-3. The .hmem file does NOT need to move — `HMEM_PATH` points to it wherever it is.
-
-4. If hmem-sync is installed, also update to v1.0.0+ (`npm update -g hmem-sync`).
-   The `--agent-id` flag was removed — use `--hmem-path` or `HMEM_PATH` instead.
-
-5. **CRITICAL — Sync filename must match across all devices:**
-   hmem-sync identifies stores by the local filename (e.g. `DEVELOPER.hmem`). If Device A
-   syncs as `DEVELOPER.hmem` and Device B syncs as `memory.hmem`, they will NOT see each
-   other's data — the server treats them as separate stores.
-
-   **Check:** Run `hmem-sync status` on each device. The "hmem file" line shows the filename
-   that will be used for sync. All devices sharing the same memory MUST use the same filename.
-
-   **Common mistake after v6.0 migration:** Devices that used `HMEM_AGENT_ID=DEVELOPER`
-   have `DEVELOPER.hmem`. New devices default to `memory.hmem`. These won't sync.
-
-   **Fix:** Rename the .hmem file on the mismatched device:
-   ```bash
-   mv ~/.hmem/memory.hmem ~/.hmem/DEVELOPER.hmem
-   # or: mv ~/.hmem/memory.hmem ~/.hmem/Agents/DEVELOPER/DEVELOPER.hmem
-   ```
-   Then update `HMEM_PATH` in the MCP config to point to the renamed file.
-
-**Also removed in v6.0.0:**
-- `min_role` parameter from `write_memory` and `update_memory` tools
-- Company store role gating (all agents can now write to company store)
-- `HMEM_AGENT_ROLE` / `COUNCIL_AGENT_ROLE` env vars
+See [references/MIGRATIONS.md](references/MIGRATIONS.md) for full v6.0.0 migration steps including hmem-sync filename matching.
 
 ---
 
 ## Step 3: Entry Migration
 
-Some versions introduce new data formats. Check if migration is needed:
+Some versions introduce new data formats. Check what version range was crossed and apply relevant migrations:
 
-**v5.1.0+ Title/Body Separation:**
-- Entries support title/body separation via blank line (title shown in listings, body on drill-down)
-- Check if old entries need title/body split:
-  ```
-  read_memory(titles_only=true)
-  ```
-- Look for entries where the title is truncated mid-word or contains too much detail
-- Fix with: `update_memory(id="L0042", content="Clear title\n\nDetailed body text")`
+- **v5.1.0+** — Title/body separation for entries
+- **v5.1.2+** — Checkpoint summaries (`[CP]`) for O-entries with >10 exchanges; skill-dialog tags
 
-**v5.1.2+ Checkpoint Summaries:**
-- O-entries with >10 exchanges should have `[CP]` checkpoint summaries
-- Check recent O-entries: `read_memory(prefix="O")`
-- If summaries are missing, write them:
-  ```
-  append_memory(id="O00XX", content="\t[CP] Factual 3-8 sentence summary of the session")
-  ```
-
-**v5.1.2+ Skill-Dialog Tags:**
-- Exchanges containing skill activations should be tagged `#skill-dialog`
-- These are auto-tagged by the checkpoint process going forward
-- For old exchanges: the checkpoint auto-tagger picks them up on the next run
+See [references/MIGRATIONS.md](references/MIGRATIONS.md) for version-specific migration procedures.
 
 **General migration pattern:**
-1. Read a sample of entries to assess the current state
-2. Identify entries that don't match the new format
-3. Fix in batches — don't try to fix everything at once
-4. Prioritize: favorites and pinned entries first, then high-access, then the rest
+1. Read a sample of entries to assess current state
+2. Identify entries that do not match the new format
+3. Fix in batches — prioritize favorites and pinned entries first, then high-access, then the rest
 
 ---
 
 ## Step 4: P-Entry Schema Enforcement (R0009)
 
-All P-entries (projects) must follow the standard L2 structure:
+Verify all active P-entries follow the standard 9-section L2 structure. Add missing sections; do not restructure entries that already conform.
 
-```
-.1 Overview
-.2 Codebase
-.3 Usage
-.4 Context
-.5 Deployment
-.6 Bugs
-.7 Protocol
-.8 Open tasks
-.9 Ideas
-```
-
-For each active P-entry:
-1. `read_memory(id="P00XX", depth=2)` — check L2 structure
-2. Compare against the schema above
-3. Add missing sections: `append_memory(id="P00XX", content="\tOverview\n\t\tCurrent state: ...")`
-4. L1 body should be: `Name | Status | Stack | Description`
-
-**Do not restructure entries that already follow the schema.** Only fix what's missing or wrong.
+See [references/SCHEMA.md](references/SCHEMA.md) for the full schema and enforcement procedure.
 
 ---
 
 ## Step 5: O-Entry Curation
 
-Check recent O-entries for quality:
+Check recent O-entries (`read_memory(prefix="O")`) for quality:
 
-```
-read_memory(prefix="O")
-```
-
-**Titles:**
-- Replace "unassigned" or generic titles (e.g., "hmem-mcp") with descriptive ones
-- Good: "Title/Body Separation design + v5.1.0 release"
-- Fix: `update_memory(id="O00XX", content="Descriptive session title")`
-
-**Tags:**
-- Every O-entry should have at least `#session`
-- Add topic tags where obvious: `#release`, `#bugfix`, `#refactor`, `#brainstorming`
-- Fix: `update_memory(id="O00XX", tags=["#session", "#release"])`
-
-**Checkpoint Summaries:**
-- O-entries with >10 exchanges and no `[CP]` summary need one
-- Write summary: `append_memory(id="O00XX", content="\t[CP] Summary...")`
-- The auto-tagger will tag it `#checkpoint-summary` on the next checkpoint run
-
-**Cleanup:**
-- Look for duplicate O-entries (same title, same date, 1-2 exchanges) — these are likely subagent artifacts
-- Mark as irrelevant or delete if clearly junk
+- **Titles** — Replace "unassigned" or generic titles with descriptive ones
+- **Tags** — Every O-entry needs at least `#session`; add topic tags where obvious (`#release`, `#bugfix`, `#refactor`)
+- **Checkpoint summaries** — O-entries with >10 exchanges and no `[CP]` summary need one
+- **Cleanup** — Look for duplicate O-entries (same title, same date, 1-2 exchanges) that are likely subagent artifacts; mark irrelevant or delete
 
 ---
 
 ## Step 6: hmem-sync Update (if installed)
-
-Check if hmem-sync is installed and needs updating:
 
 ```bash
 which hmem-sync && hmem-sync --version  # check if installed
 npm view hmem-sync version              # latest on npm
 ```
 
-If outdated:
-```bash
-npm update -g hmem-sync
-```
+If outdated, run `npm update -g hmem-sync`, then verify with `hmem-sync status`, `hmem-sync push`, and `hmem-sync pull`.
 
-Verify sync still works:
-```bash
-hmem-sync status    # check connection to sync server
-hmem-sync push      # test push
-hmem-sync pull      # test pull
-```
-
-**If hmem-sync is not installed:** Skip this step. Mention to the user that hmem-sync is available for cross-device sync.
+If hmem-sync is not installed, mention it is available for cross-device sync.
 
 ---
 
 ## Step 7: Restart Prompt
 
-**IMPORTANT:** The smoke test must run against the NEW MCP server version. Since the MCP
-server is loaded into the host process (Claude Code, Gemini CLI, etc.), an npm update does
-NOT take effect until the tool is restarted.
+The smoke test must run against the new MCP server version. Since the MCP server is loaded into the host process, an npm update does NOT take effect until the tool is restarted.
 
-Tell the user:
+Tell the user to restart Claude Code and run `/hmem-update` again — it will skip straight to the smoke test.
 
-```
-All migration steps complete. Please restart Claude Code now to load the new MCP server.
-After restart, run /hmem-update again — I'll skip straight to the smoke test.
-```
-
-**If already on latest version** (detected in Step 1): Skip this step — the MCP server
-is already running the current version. Proceed directly to the smoke test.
-
-**After restart:** When `/hmem-update` runs again and Step 1 shows "already on latest",
-proceed to the smoke test immediately.
+**If already on latest** (detected in Step 1): Skip this step and proceed directly to smoke test.
 
 ---
 
 ## Step 8: Smoke Test
 
-Verify everything works after the update. **Only run this after the restart** (or if no
-update was installed — i.e., already on latest version).
+Run after restart (or immediately if no update was installed):
 
 ```
 read_memory()                           # bulk read works
@@ -339,14 +156,13 @@ update_memory(id="T00XX", content="Update smoke test — verified", irrelevant=t
                                         # update works + mark for cleanup
 ```
 
-If any step fails: report the error to the user. Do not proceed with normal work until the issue is resolved.
+If any step fails, report the error. Do not proceed with normal work until resolved.
 
 ---
 
 ## Step 9: Report
 
-Tell the user what was done. **Always remind to restart** if an actual update was
-installed and the user hasn't restarted yet.
+Tell the user what was done. Always remind to restart if an update was installed and the user has not restarted yet. Example:
 
 ```
 hmem-mcp updated: v5.1.2 → v5.1.4
@@ -356,23 +172,16 @@ Changes applied:
 - 5 P-entries checked against R0009 schema (2 fixed)
 - 12 O-entries curated (4 titles fixed, 3 summaries added)
 - Smoke test passed ✓
-
-New features in this version:
-- Rolling checkpoint summaries
-- Skill-dialog exchange filtering
-- hmem --version reads from package.json
 ```
 
 ---
 
 ## Auto-Detection (for hook integration)
 
-This skill can be triggered automatically. At session startup, if the hmem MCP server detects that the installed version differs from the last-seen version stored in the config, it appends a notice to the first `read_memory()` response:
+This skill can be triggered automatically. At session startup, if the hmem MCP server detects a version mismatch, it appends a notice to the first `read_memory()` response:
 
 ```
 ⚠ hmem-mcp updated: v5.1.2 → v5.1.4. Run /hmem-update to apply post-update steps.
 ```
 
-The agent should then invoke this skill automatically or ask the user if they want to run it.
-
-**Last-seen version** is stored in `hmem.config.json` under `lastSeenVersion`. Updated automatically after a successful `/hmem-update` run.
+The agent should then invoke this skill automatically or ask the user. Last-seen version is stored in `hmem.config.json` under `lastSeenVersion`.

--- a/skills/hmem-update/references/MIGRATIONS.md
+++ b/skills/hmem-update/references/MIGRATIONS.md
@@ -1,0 +1,93 @@
+# Version-Specific Migrations
+
+## v6.0.0 — HMEM_PATH Migration
+
+v6.0.0 replaced `HMEM_PROJECT_DIR` + `HMEM_AGENT_ID` with a single `HMEM_PATH` env var.
+
+### Check if migration is needed
+
+1. Look at the user's `.mcp.json` or `~/.claude.json` for hmem env vars
+2. If you see `HMEM_PROJECT_DIR` and/or `HMEM_AGENT_ID` — migration needed
+
+### Migration steps
+
+1. Determine the current .hmem file path:
+   - With agent ID: `{HMEM_PROJECT_DIR}/Agents/{HMEM_AGENT_ID}/{HMEM_AGENT_ID}.hmem`
+   - Without: `{HMEM_PROJECT_DIR}/memory.hmem`
+
+2. Update MCP config — replace old env vars with `HMEM_PATH`:
+   ```json
+   {
+     "env": {
+       "HMEM_PATH": "/absolute/path/to/your/file.hmem"
+     }
+   }
+   ```
+   Remove `HMEM_PROJECT_DIR`, `HMEM_AGENT_ID`, and `HMEM_AGENT_ROLE` from the env block.
+
+3. The .hmem file does NOT need to move — `HMEM_PATH` points to it wherever it is.
+
+4. If hmem-sync is installed, also update to v1.0.0+ (`npm update -g hmem-sync`).
+   The `--agent-id` flag was removed — use `--hmem-path` or `HMEM_PATH` instead.
+
+5. **CRITICAL — Sync filename must match across all devices:**
+   hmem-sync identifies stores by the local filename (e.g. `DEVELOPER.hmem`). If Device A
+   syncs as `DEVELOPER.hmem` and Device B syncs as `memory.hmem`, they will NOT see each
+   other's data — the server treats them as separate stores.
+
+   **Check:** Run `hmem-sync status` on each device. The "hmem file" line shows the filename
+   that will be used for sync. All devices sharing the same memory MUST use the same filename.
+
+   **Common mistake after v6.0 migration:** Devices that used `HMEM_AGENT_ID=DEVELOPER`
+   have `DEVELOPER.hmem`. New devices default to `memory.hmem`. These will not sync.
+
+   **Fix:** Rename the .hmem file on the mismatched device:
+   ```bash
+   mv ~/.hmem/memory.hmem ~/.hmem/DEVELOPER.hmem
+   # or: mv ~/.hmem/memory.hmem ~/.hmem/Agents/DEVELOPER/DEVELOPER.hmem
+   ```
+   Then update `HMEM_PATH` in the MCP config to point to the renamed file.
+
+### Also removed in v6.0.0
+
+- `min_role` parameter from `write_memory` and `update_memory` tools
+- Company store role gating (all agents can now write to company store)
+- `HMEM_AGENT_ROLE` / `COUNCIL_AGENT_ROLE` env vars
+
+---
+
+## v5.1.2 — Checkpoint Summaries and Skill-Dialog Tags
+
+### Checkpoint Summaries
+
+O-entries with >10 exchanges should have `[CP]` checkpoint summaries. Check recent O-entries:
+
+```
+read_memory(prefix="O")
+```
+
+If summaries are missing, write them:
+
+```
+append_memory(id="O00XX", content="\t[CP] Factual 3-8 sentence summary of the session")
+```
+
+### Skill-Dialog Tags
+
+Exchanges containing skill activations should be tagged `#skill-dialog`. These are auto-tagged by the checkpoint process going forward. For old exchanges, the checkpoint auto-tagger picks them up on the next run.
+
+---
+
+## v5.1.0 — Title/Body Separation
+
+Entries support title/body separation via blank line (title shown in listings, body on drill-down). Check if old entries need title/body split:
+
+```
+read_memory(titles_only=true)
+```
+
+Look for entries where the title is truncated mid-word or contains too much detail. Fix with:
+
+```
+update_memory(id="L0042", content="Clear title\n\nDetailed body text")
+```

--- a/skills/hmem-update/references/SCHEMA.md
+++ b/skills/hmem-update/references/SCHEMA.md
@@ -1,0 +1,26 @@
+# P-Entry Schema (R0009)
+
+All P-entries (projects) must follow the standard L2 structure:
+
+```
+.1 Overview
+.2 Codebase
+.3 Usage
+.4 Context
+.5 Deployment
+.6 Bugs
+.7 Protocol
+.8 Open tasks
+.9 Ideas
+```
+
+## Enforcement procedure
+
+For each active P-entry:
+
+1. `read_memory(id="P00XX", depth=2)` — check L2 structure
+2. Compare against the schema above
+3. Add missing sections: `append_memory(id="P00XX", content="\tOverview\n\t\tCurrent state: ...")`
+4. L1 body should be: `Name | Status | Stack | Description`
+
+Do not restructure entries that already follow the schema. Only fix what is missing or wrong.

--- a/skills/hmem-update/references/WINDOWS-HOOKS.md
+++ b/skills/hmem-update/references/WINDOWS-HOOKS.md
@@ -1,0 +1,41 @@
+# Windows Hook Troubleshooting
+
+Two specific issues break hooks on Windows. Always run these checks when updating on Windows.
+
+## Check 1 — `shell: powershell` present on every hook command?
+
+Each object in `hooks.*.hooks` and the `statusLine` object must contain `"shell": "powershell"`. Without it, Claude Code may route the command through Git Bash, whose MSYS2 runtime crashes transiently at startup (`bash.exe: *** fatal error - add_item ... errno 1`) before the command is even parsed. Every hook then fails with a generic error.
+
+## Check 2 — No inline env-var syntax in commands?
+
+Commands must NOT contain `VAR=value` prefixes like `HMEM_PATH=C:/... node ...`. That is bash-only syntax; cmd.exe and PowerShell interpret `HMEM_PATH=...` as the command name and fail. All env vars must live in the top-level `env` block of settings.json.
+
+## Correct Windows shape
+
+```json
+{
+  "env": {
+    "HMEM_PATH": "C:/Users/<you>/.hmem/Agents/<AGENT>/<AGENT>.hmem"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/<you>/AppData/Roaming/npm/node_modules/hmem-mcp/dist/cli.js log-exchange",
+            "shell": "powershell"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Remediation
+
+If either check fails, offer to fix settings.json automatically. The fix is lossless on other platforms, so it is safe to apply even on shared configs synced across OSes. Point the user to the Windows hook section in `/hmem-config` for the full pattern (UserPromptSubmit, Stop, SessionStart, statusLine).
+
+After fixing, Claude Code must be restarted so the `env` block is re-loaded and hooks are re-registered with the new shell.

--- a/skills/hmem-write/SKILL.md
+++ b/skills/hmem-write/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: hmem-write
-description: How to write long-term memories. Follow these rules whenever you call write_memory.
+description: "Store facts, preferences, decisions, and project context into hmem long-term memory using the write_memory MCP tool. Use when the user says 'remember this', 'save this', 'don't forget', 'store this for later', or invokes /hmem-write. Persists key lessons, error resolutions, architecture decisions, user preferences, and project state across sessions. Use when Claude should record conversation insights, save project context, persist important facts, or store user preferences for future reference."
 ---
 
 # How to use write_memory
 
-When you need to save a lesson, error, decision, or project insight to long-term memory,
-call the MCP tool `write_memory` following these rules.
+Call the MCP tool `write_memory` to save lessons, errors, decisions, or project insights to long-term memory.
 
-If the tool `write_memory` is not available:
+If `write_memory` is not available:
 1. Tell the user: "write_memory tool not found. Please reconnect the MCP server (in Claude Code: `/mcp`, in other tools: restart the tool)."
-2. **NEVER write directly to the .hmem SQLite file via shell commands.** The database has WAL journaling, integrity checks, and tree-structure logic that raw SQL INSERT will bypass — causing corruption or data loss.
+2. **NEVER write directly to the .hmem SQLite file via shell commands.** The database uses WAL journaling and integrity checks that raw SQL will bypass.
 
 ---
 
@@ -23,12 +22,12 @@ write_memory(
 )
 ```
 
-**Title + Body convention (git-commit style):** Every node has a **title** (short navigation label) and an optional **body** (detailed content loaded on drill-down). Separate them with a **blank line** — just like a git commit message.
+**Title + Body convention (git-commit style):** Every node has a **title** (short navigation label) and an optional **body** (detailed content). Separate them with a **blank line**.
 
-- **Title:** The first line (L1) or first line at a given indent level (L2+). ~50 chars, like a chapter title.
-- **Body:** Everything after the blank line at the same indent level. Freetext, no special prefix needed. Shown only when the node is drilled into, not in listings.
+- **Title:** First line at a given indent level. ~50 chars, like a chapter title.
+- **Body:** Everything after the blank line at the same indent level. Shown only on drill-down, not in listings.
 - **Legacy `> ` prefix:** Still works for backward compatibility, but blank-line separation is preferred.
-- **Without body:** The full text is stored as `content` and the title is auto-extracted from the first `maxTitleChars` characters.
+- **Without body:** Full text stored as `content`, title auto-extracted from first `maxTitleChars` characters.
 
 **L1 example with body:**
 ```
@@ -41,25 +40,17 @@ The fix was to use an absolute path in the HMEM_PATH env var.
 	Steps: 1. Set HMEM_PATH=./hmem  2. Run hmem serve  3. Observe SQLITE_CANTOPEN
 ```
 
-**L1 example without body (still works):**
-```
-SQLite connection failed due to wrong path in .mcp.json
-	Fix: use absolute path in env var
-```
-
 **Indentation:** 1 tab = 1 level. Alternatively: 2 or 4 spaces per level (auto-detected).
-**Warning:** A tab at the start of any line always means "go one level deeper" — it is structural, not content. If you need to store code or text that contains leading tabs, use spaces instead.
-**IDs and timestamps** are assigned automatically — never write them yourself.
+**Warning:** A tab at the start of any line always means "go one level deeper" — it is structural. Store code/text with leading tabs using spaces instead.
+**IDs and timestamps** are assigned automatically — never write them manually.
 
 ---
 
-## Hashtags — strongly recommended on every write_memory and append_memory call
+## Hashtags — add to every write_memory and append_memory call
 
-Hashtags connect entries **across all prefixes and hierarchy levels**. They are the only way to find
-all `#hmem`-related entries at once — regardless of whether they are P, E, L, or T.
-Without tags, entries become isolated islands that are hard to discover later.
+Hashtags connect entries **across all prefixes and hierarchy levels**. They are the only cross-prefix discovery mechanism.
 
-**Add tags to every write_memory and append_memory call.** Aim for 3 minimum, 5+ is better:
+**Add 3-5 tags per call (max 10):**
 ```
 write_memory(prefix="E", content="...", tags=["#hmem", "#sqlite", "#bug", "#migration", "#windows"])
 append_memory(id="P0029", content="...", tags=["#hmem", "#sync", "#cli"])
@@ -67,21 +58,12 @@ append_memory(id="P0029", content="...", tags=["#hmem", "#sync", "#cli"])
 
 **Rules:**
 - Lowercase, starts with `#`, only letters/digits/hyphen/underscore: `#hmem-sync`, `#api_key`
-- Max 10 tags per entry. **Aim for 3–5 per entry** — more connections = better discoverability
 - `append_memory` tags are **additive** — they do not replace existing tags
-- `write_memory` tags: if entry has children → land on **first child node**; if leaf (no children) → land on **root**
-- `append_memory` tags are stored **only on the target node** — no upward propagation
-- Every node at any depth can have its own tags — use this to make sub-topics discoverable
+- `write_memory` tags: if entry has children -> land on **first child node**; if leaf -> land on **root**
+- Every node at any depth can have its own tags
 
-**Good tags:** `#hmem`, `#sync`, `#sqlite`, `#windows`, `#release`, `#bug`, `#security`, `#althing`, `#cli`, `#migration`
+**Good tags:** `#hmem`, `#sync`, `#sqlite`, `#windows`, `#release`, `#bug`, `#security`, `#cli`, `#migration`
 **Bad tags:** `#fix` (too generic), `#important` (no context), `#2026` (not a topic)
-
-**Bulk-tagging** for existing entries:
-```
-tag_bulk(filter={prefix: "E"}, add_tags=["#bug"])           # all E-entries
-tag_bulk(filter={search: "hmem-sync"}, add_tags=["#sync"])  # by full-text search
-tag_rename(old_tag="#hmem-store", new_tag="#hmem")           # rename a tag everywhere
-```
 
 ---
 
@@ -89,211 +71,130 @@ tag_rename(old_tag="#hmem-store", new_tag="#hmem")           # rename a tag ever
 
 | Prefix | Category | When to use |
 |--------|----------|-------------|
-| **P** | (P)roject | Project entries — standardized L1 format (see below) |
+| **P** | (P)roject | Project entries — standardized L1 format |
 | **L** | (L)esson | Lessons learned, best practices — cross-project knowledge |
-| **E** | (E)rror | Bugs, errors + their fix — auto-scaffolded schema (see below) |
-| **D** | (D)ecision | Architecture decisions with reasoning — cross-project knowledge |
-| **T** | (T)ask | Cross-project or infrastructure tasks ONLY (see note below) |
-| **M** | (M)ilestone | Cross-project milestones ONLY — project milestones go in P-entry L2 "Protocol" |
+| **E** | (E)rror | Bugs, errors + their fix — auto-scaffolded schema |
+| **D** | (D)ecision | Architecture decisions with reasoning |
+| **T** | (T)ask | Cross-project or infrastructure tasks ONLY |
+| **M** | (M)ilestone | Cross-project milestones ONLY |
 | **S** | (S)kill | Skills, processes, how-to guides |
 | **N** | (N)avigator | Code pointers — where something lives in the codebase |
 | **H** | (H)uman | Knowledge about the user — preferences, context, working style |
-| **R** | (R)ule | User-defined rules and constraints — "always do X", "never do Y" |
-| **I** | (I)nfrastructure | Devices, servers, deployments, network — one entry per device/server |
+| **R** | (R)ule | User-defined rules and constraints |
+| **I** | (I)nfrastructure | Devices, servers, deployments, network |
 
-### Where do tasks, errors, lessons, and decisions go?
+-> See [references/PREFIXES.md](references/PREFIXES.md) for placement rules (where tasks/errors/milestones belong), custom prefixes, markers, Navigator entries, bulk tag operations, and access scoring.
 
-**Tasks** belong inside the project's P-entry L2 "Open tasks" node:
-```
-append_memory(id="P0048.8", content="Implement multi-server sync\n\tPush/pull to all configured servers", tags=["#hmem-sync"])
-```
-Use the T-prefix ONLY for tasks that span multiple projects or are infrastructure/meta tasks (e.g. "Set up Strato server", "Run curation pass"). These get `links=["P00XX"]` to the most relevant project.
+-> See [references/P-SCHEMA.md](references/P-SCHEMA.md) for P-entry standard schema, status values, L2 categories, and the WeatherBot example.
 
-**Milestones** belong in the P-entry L2 "Protocol" node as a chronological entry:
-```
-append_memory(id="P0048.7", content="v4.0.0 published — project gate + load_project tool (2026-03-27)", tags=["#release"])
-```
-Use the M-prefix ONLY for milestones that span multiple projects (e.g. "First cross-device sync working").
+-> See [references/E-SCHEMA.md](references/E-SCHEMA.md) for E-entry auto-scaffolded schema, favorites, and obsolete marking.
 
-**Errors (E), Lessons (L), Decisions (D)** stay as independent root entries — they are **cross-project knowledge**. An SQLite lesson learned in hmem applies to every SQLite project. Always add `tags` and `links` to connect them back:
-```
-write_memory(prefix="E", content="...", tags=["#hmem", "#sqlite"], links=["P0048"])
-```
-
-**P-entry "Known issues" (L2)** contains short summaries pointing to E-entries — not the errors themselves:
-```
-append_memory(id="P0048.6", content="Auto-sync fails with multiple .hmem in CWD → E0097, T0043", tags=["#hmem-sync"])
-```
-
-**Custom prefixes:** If none of the above fit, you can use any single uppercase letter. To register it officially (so the system validates it), add it to `hmem.config.json` under `"prefixes"`:
-```json
-{ "prefixes": { "R": "Research" } }
-```
-Custom prefixes are merged with the defaults — they don't replace them. Without registering, the system will reject the prefix.
-
-### P-Entry Standard Schema (enforced by MCP server)
-
-Every project entry MUST follow this structure. The MCP server validates L2 nodes
-against the standard categories when `prefix="P"`.
-
-**L1 Title:** `Name | Status | Tech Stack | GH: owner/repo | Short description`
-The GH field is optional — include it when a GitHub repo exists, omit otherwise.
-**L1 Body:** (same line or next non-indented line) One-sentence project summary.
-
-**Status values:**
-
-| Status | Meaning |
-|--------|---------|
-| New | Just started, concept phase |
-| Active | In active development |
-| Mature | Feature-complete, only bugfixes |
-| Paused | On hold, will resume later |
-| Archived | Done or abandoned |
-
-**L2 categories (fixed order, skip sections that are empty):**
-
-The MCP server validates that L2 nodes start with one of these names. Minimum for a new project: Overview + Codebase (or Usage).
-
-| L2 Category | What goes here | L3 children |
-|-------------|---------------|-------------|
-| **Overview** | First thing an agent reads (like CLAUDE.md /init) | Current state, Goals, Architecture, Environment |
-| **Codebase** | Code structure — NO code, only names + signatures | Entry point, Core modules (each module = L4 node with signature + purpose + return), Helpers, Config, Tests |
-| **Usage** | How the project is used | Installation/Setup, CLI/API commands, Common workflows |
-| **Context** | Background and motivation | Initiator, Target audience, Business context, Dependencies (links) |
-| **Deployment** | Build/CI/CD/publish process | (flat or with L3 sub-steps) |
-| **Bugs** | Active bugs + known limitations | L3: inline report (symptom + cause) OR pointer to E-entry (`→ E0097`). L4: reproduction steps |
-| **Protocol** | Session log, chronological | One-liner per session + links to O-entries |
-| **Open tasks** | Project-specific TODOs | One per L3 node. Cross-project tasks → T-prefix with links |
-| **Ideas** | Feature ideas, brainstorming | L3: short description, L4: implementation details |
-
-**load_project tool:** Use `load_project(id="P0048")` to activate a project and get the full briefing (L2 content + L3 titles) in one call. This is the recommended way to start working on a project — it combines read + activate.
-
-**Markers you may see on entries:**
-
-| Marker | Meaning |
-|--------|---------|
-| `[♥]` | Favorite — always expanded in bulk reads |
-| `[★]` | Top-accessed — high weighted access score |
-| `[≡]` | Top-subnode — many children |
-| `[⚡]` | Task-promoted — relevant to an active T/P/D entry (tag overlap) |
-| `[*]` | Active — currently in focus |
-| `[P]` | Pinned — super-favorite, shows full L2 |
-| `[!]` | Obsolete — superseded, kept for history |
-| `[-]` | Irrelevant — hidden from bulk reads |
-| `✓` | Synced — backed up to all sync servers |
-
-**Complete P-entry example (WeatherBot):**
-
-```
-write_memory(
-  prefix="P",
-  content="WeatherBot | New | Python/Discord.py | GH: user/weatherbot\n\nDiscord bot for weather forecasts — slash commands for current weather and multi-day forecasts\n\tOverview\n\t\tCurrent state\n\n\t\tScaffolding done, no commands yet. Bot connects to Discord but has no slash commands registered.\n\t\tGoals\n\n\t\tDaily/hourly forecasts via slash commands, multi-city support, embed formatting\n\t\tArchitecture\n\n\t\tDiscord slash command → OpenWeatherMap API → formatted embed. Single-file cog pattern.\n\t\tEnvironment\n\n\t\t/home/user/weatherbot, python bot.py, needs DISCORD_TOKEN + WEATHER_API_KEY in .env\n\tCodebase\n\t\tEntry point — bot.py, start: python bot.py\n\t\tCore modules\n\t\t\tweather_cog.py — WeatherCog(Cog); fetch_forecast(city: str) → discord.Embed\n\t\t\tformatter.py — format_embed(data: dict) → discord.Embed\n\t\tHelpers / Utilities\n\t\t\tapi_client.py — get_weather(city: str) → dict; wraps HTTP to OpenWeatherMap\n\t\tConfig / Constants — .env: DISCORD_TOKEN, WEATHER_API_KEY, DEFAULT_CITY\n\t\tTests — pytest, test_weather_cog.py (3 tests)\n\tUsage\n\t\tInstallation / Setup — pip install -r requirements.txt, cp .env.example .env\n\t\tCLI / API — /weather <city>, /forecast <city> (planned)\n\tContext\n\t\tInitiator — personal project, Mar 2026\n\t\tTarget audience — personal Discord server\n\t\tDependencies — discord.py, OpenWeatherMap API, aiohttp\n\tOpen tasks\n\t\tImplement /forecast command\n\n\t\tMulti-day view with daily highs/lows and weather icons per day\n\t\tAdd city autocomplete",
-  tags=["#discord", "#python", "#weather", "#bot"],
-  links=[]
-)
-```
-
-Note: L2 nodes use 1 tab, L3 uses 2 tabs, L4 uses 3 tabs. Separate title from body with a blank line at the same indent level. Skip empty sections — no need for placeholder text.
-
-### E-Entry Schema (auto-scaffolded)
-
-E-entries have a **pre-built structure** — just provide a title and short description, the server creates the rest:
-
-```
-write_memory(prefix="E", content="hmem sync bug on v1.0.1\n\nConnection fails when HMEM_PATH contains spaces", tags=["#hmem", "#sync", "#path"])
-```
-
-This auto-creates:
-- **.1 Analysis** (your description goes here automatically)
-- **.2 Possible fixes**
-- **.3 Fixing attempts**
-- **.4 Solution**
-- **.5 Cause**
-- **.6 Key Learnings**
-
-Plus `#open` tag. Fill in the nodes as you debug with `append_memory`/`update_memory`. The response shows **similar E/D entries by tag overlap** — check them before reinventing the wheel. When solved, replace `#open` with `#solved` and fill .4 + .5 + .6.
-
-E-entries are **not shown in bulk reads** — they surface automatically via tag overlap when you create new E/D entries. Solved bugs are knowledge, not clutter.
-
-### Marking entries as favorites
-
-Mark any entry as a favorite to ensure it always appears with its L2 detail in bulk reads (alongside a `[♥]` marker). Use this for reference info you need to see every session — API endpoints, key decisions, frequently looked-up patterns.
-
-```
-write_memory(prefix="D", content="...", favorite=true)           # set at creation
-update_memory(id="D0010", content="...", favorite=true)          # set on existing
-update_memory(id="D0010", content="...", favorite=false)         # clear
-```
-
-Favorites are **not** a prefix — they are a flag on any entry regardless of category.
-Use sparingly: if everything is a favorite, nothing is. Prefer high-value reference entries over fleeting notes.
-
----
-
-### Marking entries as obsolete
-
-When you notice that an entry is outdated — superseded by a newer approach, a fixed bug, or changed architecture — do **not** delete it. Mark it as obsolete with a correction reference:
-
-```
-# Step 1: Write the correction FIRST
-write_memory(prefix="E", content="Correct approach is XYZ\n\tDetails...")  # → E0076
-
-# Step 2: Mark old entry obsolete — MUST include [✓ID] tag
-update_memory(id="E0023", content="Wrong approach — see [✓E0076]", obsolete=true)
-```
-
-**The `[✓ID]` tag is enforced.** The system will reject `obsolete=true` without a correction reference. This ensures every obsolete entry points to its replacement. The system also creates **bidirectional links** automatically (E0023↔E0076).
-
-The entry stays in memory with a `[!]` marker. Past errors still carry learning value ("we tried this and it failed because..."). The curator may eventually prune it, but that's their decision, not yours.
-
-**Shortcut for stale entries:** If no correction exists (entry is just old/irrelevant, not wrong), only the curator can mark it obsolete without `[✓ID]`.
-
----
-
-### N — Navigator (Code Pointers)
-
-Use `N` to save a pointer to a specific file, function, or code location so you don't have to search for it next session.
-
-```
-write_memory(
-  prefix="N",
-  content="Link-Auflösung beim read_memory-Aufruf
-	src/hmem-store.ts ~line 269 — read() method, ID branch
-	Guard: resolveLinks !== false prevents circular refs
-	Introduced in v1.4.0",
-  links=["E0069"]
-)
-```
-
-**L1:** What it is — one sentence describing the concept/feature
-**L2:** Exact file path + line range + function/method name
-**L3:** Context, caveats, related patterns
-**Links:** Related entries (errors, decisions, lessons)
-
-**Your responsibility:** Update your N entries whenever you notice code has moved or logic has changed. You don't need the curator for this — use `update_memory` directly. Stale pointers are worse than none. If you cannot verify whether the pointer is still valid, mark it obsolete: `update_memory(id="N0012", content="...", obsolete=true)`.
+-> See [references/H-ASSESSMENT.md](references/H-ASSESSMENT.md) for H-prefix user skill assessment guide.
 
 ---
 
 ## Title + Body Quality Rules
 
-**Title:** Short navigation label, ~50 chars (configurable via `maxTitleChars`). Think "chapter title in a book".
+**Title:** Short navigation label, ~50 chars. Think "chapter title in a book".
 - Good: `"hmem.py Performance: Bulk-Queries statt N+1"`, `"Ghost Wakeup Bug in msg-router.ts"`
 - Bad: `"Fixed a bug"`, `"Important lesson"` (too vague)
 
-**Body (after blank line):** Detailed explanation — full sentences, multiline OK. Shown on drill-down, hidden in listings.
-- Must be understandable without any context
-- Not "Fixed a bug" — instead explain root cause, fix, and impact
+**Body (after blank line):** Detailed explanation — full sentences, multiline OK. Must be understandable without context.
 
-**With title + body (recommended):**
+---
+
+## Navigate the Tree Before Writing
+
+**Never write blindly.** Navigate the existing tree top-down to find the correct insertion point. New information almost always belongs inside an existing entry — not as a new root.
+
+### Protocol
+
+**Step 1 — Check L1 summaries (already in context)**
+Scan root entries. Is there a matching root for this topic?
+- **No match** -> `write_memory()` creates a new root
+- **Match found** -> continue to Step 2
+
+**Step 2 — Read the matching root's children**
 ```
-write_memory(prefix="L", content="hmem.py Performance: Bulk-Queries statt N+1\n\nAlle Nodes in 2 Bulk-Queries laden, nicht pro Entry einzeln.\nVorher: load_nodes() pro Entry = N+1 SQLite-Connections.\n\tImplementation detail\n\n\tChanged read() to batch-fetch all nodes for visible entries in one query")
+read_memory(id="P0029")   # shows root + all L2 titles
+```
+- **No L2 match** -> `append_memory(id="P0029", content="...")` adds a new L2
+- **Match found (e.g. .15)** -> continue to Step 3
+
+**Step 3 — Drill into that L2**
+```
+read_memory(id="P0029.15")   # shows L2 node + all L3 titles
+```
+- **No L3 match** -> `append_memory(id="P0029.15", content="...")` adds a new L3
+- **Match found** -> continue drilling
+
+**Stop drilling when:** no child matches, or the level of granularity fits.
+
+### When write_memory Is Correct
+
+Only use `write_memory` when:
+- No root entry exists for this topic
+- The topic is genuinely orthogonal (different error, different decision, different project)
+- Creating an E/L/D entry for a new root cause, not extending an existing one
+
+**Rule:** If in doubt, drill one level deeper before creating a new root.
+
+---
+
+## When to Save
+
+**Checkpoint mode matters.** Check `checkpointMode` in hmem.config.json:
+
+- **`"auto"` (recommended):** A background Haiku subagent handles checkpoints automatically. The agent does NOT need to write entries unless the user explicitly asks to save something specific.
+- **`"remind"`:** The agent receives a CHECKPOINT reminder every N messages. Save key learnings using `write_memory` / `append_memory` when prompted.
+
+**In both modes:** Only save what is still valuable in 6 months.
+
+| Save | Do not save |
+|------|-------------|
+| New root cause + fix | Routine actions without learning value |
+| Insight that changes future work | What is already in the codebase |
+| Architecture decision + reasoning | Temporary debugging notes |
+| Unexpected tool/API behavior | What is in the documentation |
+
+One `write_memory` call per category — entire hierarchy in one `content` string.
+
+---
+
+## Updating Existing Memories
+
+### update_memory — Fix outdated text
+
+Updates the text of a single node. Children are **not** touched.
+
+```
+update_memory(id="L0003", content="Corrected L1 summary — new wording")
+update_memory(id="D0010", content="New L1", links=["E0042"])  # also update links
 ```
 
-**Without body (simple entries, backward-compatible):**
+Use when: wording is wrong, outdated, or needs clarification.
+
+### append_memory — Add detail to existing entry
+
+Appends new child nodes under an existing root or node. Existing children are preserved.
+Content indentation is **relative to the parent** — 0 tabs = direct child of `id`.
+
 ```
-write_memory(prefix="E", content="SQLite connection failed due to wrong path in .mcp.json\n\tFix: use absolute path in env var")
+append_memory(
+  id="L0003",
+  content="New finding discovered later\n\nDetailed explanation of what was found and why it matters.\n\tSub-detail about it"
+)
+# -> adds L0003.N (L2 with title + body) and L0003.N.1 (L3)
 ```
-Title auto-extracted: `"SQLite connection failed due to wrong path in .mc"`
+
+### Decision Table
+
+| Situation | Tool |
+|-----------|------|
+| L1 wording is wrong/outdated | `update_memory` |
+| A sub-node has wrong detail | `update_memory` |
+| New info to add | `append_memory` |
+| Entry is completely wrong | curator: `delete_agent_memory` + `write_memory` |
 
 ---
 
@@ -309,241 +210,9 @@ write_memory(
 
 ---
 
-## Before Writing: Navigate the Tree First
-
-**Never write blindly.** Before creating a new entry or appending, navigate the existing tree top-down to find the correct insertion point. New information almost always belongs inside an existing entry — not as a new root.
-
-### Protocol
-
-**Step 1 — Check L1 summaries (already in context)**
-Scan the root entries visible in your context. Is there a matching root for this topic?
-
-- **No match** → `write_memory()` creates a new root
-- **Match found** → continue to Step 2
-
-**Step 2 — Read the matching root's children**
-```
-read_memory(id="P0029")   # shows root + all L2 titles
-```
-Do any L2 titles match the sub-topic?
-
-- **No match** → `append_memory(id="P0029", content="...")` adds a new L2
-- **Match found (e.g. .15)** → continue to Step 3
-
-**Step 3 — Drill into that L2**
-```
-read_memory(id="P0029.15")   # shows L2 node + all L3 titles
-```
-Does an L3 match even more specifically?
-
-- **No match** → `append_memory(id="P0029.15", content="...")` adds a new L3
-- **Match found** → continue drilling (Step 4: `read_memory(id="P0029.15.2")`, etc.)
-
-**Stop drilling when:** no child matches, or you've reached the level of granularity that fits.
-
-### Example
-
-New insight about MCP server restart behavior after TypeScript compile:
-
-```
-# Step 1: L1 summaries show L0074 "MCP server muss nach Kompilierung neugestartet werden"
-# Step 2: read_memory(id="L0074") → shows .1 "Fix: kill + auto-respawn", .2 "Context: Althing only"
-# No L2 matches the new sub-case → append at L2
-
-append_memory(id="L0074", content="Standalone hmem-mcp: npm restart required (no auto-respawn)")
-# → adds L0074.3 (L3 under the existing lesson)
-```
-
-Instead of: `write_memory(prefix="L", content="MCP restart needed after compile...")` — which would duplicate L0074.
-
-### When `write_memory` is correct
-
-Only use `write_memory` when:
-- No root entry exists for this topic at all
-- The topic is genuinely orthogonal (different error, different decision, different project)
-- You're creating an E/L/D entry for a new root cause, not an extension of an existing one
-
-**Rule:** If in doubt, drill one level deeper before deciding to create a new root.
-
----
-
-## When to save?
-
-**Checkpoint mode matters.** Check `checkpointMode` in hmem.config.json:
-
-- **`"auto"` (recommended):** A background Haiku subagent handles checkpoints automatically every N exchanges. It reads recent O-entry exchanges, calls `read_memory` to avoid duplicates, and writes L/D/E entries + handoff via MCP tools. It also writes a rolling checkpoint summary (`[CP]` node tagged `#checkpoint-summary`) that compresses older exchanges for `load_project`. Skill-dialog exchanges are auto-tagged `#skill-dialog` and filtered from context injection. **You do NOT need to write entries yourself** unless the user explicitly asks you to save something specific.
-
-- **`"remind"`:** You will receive a CHECKPOINT reminder every N messages. When you see it, save key learnings yourself using `write_memory` / `append_memory`.
-
-**In both modes:** Only save what is still valuable in 6 months.
-
-| Save | Don't save |
-|------|-----------|
-| New root cause + fix | Routine actions without learning value |
-| Insight that changes future work | What's already in the codebase |
-| Architecture decision + reasoning | Temporary debugging notes |
-| Unexpected tool/API behavior | What's in the documentation |
-
-One `write_memory` call per category — entire hierarchy in one `content` string.
-
----
-
-## Updating Existing Memories
-
-Use `update_memory` and `append_memory` to modify entries without deleting and recreating them.
-
-### update_memory — Fix outdated text
-
-Updates the text of a single node. Children are **not** touched.
-
-```
-update_memory(id="L0003", content="Corrected L1 summary — new wording")
-update_memory(id="L0003.2", content="Fixed L2 detail")
-update_memory(id="D0010", content="New L1", links=["E0042"])  # also update links
-```
-
-Use when: the wording is wrong, outdated, or needs clarification.
-
-### append_memory — Add detail to existing entry
-
-Appends new child nodes under an existing root or node. Existing children are preserved.
-
-Content indentation is **relative to the parent** — 0 tabs = direct child of `id`.
-Body works the same as in `write_memory` — blank line separates title from body.
-
-```
-append_memory(
-  id="L0003",
-  content="New finding discovered later\n\nDetailed explanation of what was found and why it matters.\nThis can span multiple lines.\n\tSub-detail about it"
-)
-# → adds L0003.N (L2 with title + body) and L0003.N.1 (L3)
-
-append_memory(
-  id="L0003.2",
-  content="Extra note under L0003.2"
-)
-# → adds L0003.2.M (L3)
-```
-
-Use when: you have new context to add without replacing what's there.
-
-### When to use which
-
-| Situation | Tool |
-|-----------|------|
-| L1 wording is wrong/outdated | `update_memory` |
-| A sub-node has wrong detail | `update_memory` |
-| You have new info to add | `append_memory` |
-| Entry is completely wrong | curator: `delete_agent_memory` + `write_memory` |
-
----
-
-## Access Count (Automatic + Time-Weighted)
-
-Access counts are managed automatically — every `read_memory` and `append_memory` call bumps the accessed entries. The ranking uses **time-weighted scoring** (`access_count / log2(age_in_days + 2)`) so newer entries with fewer accesses can outrank stale old ones. Entries with the highest weighted scores get `[★]` markers and expanded treatment in bulk reads. To explicitly mark an entry as important, use `favorite: true` on `write_memory` or `update_memory`.
-
----
-
-## Bulk Tag Operations
-
-Apply tags to multiple entries at once, or rename a tag everywhere:
-
-```
-# Add #bugfix to all E-prefix entries
-tag_bulk(filter={prefix: "E"}, add_tags=["#bugfix"])
-
-# Add tag to entries matching a search term
-tag_bulk(filter={search: "FTS5"}, add_tags=["#search", "#sqlite"])
-
-# Remove #old from all entries that have it
-tag_bulk(filter={tag: "#old"}, remove_tags=["#old"])
-
-# Add and remove simultaneously
-tag_bulk(filter={prefix: "L", tag: "#draft"}, add_tags=["#stable"], remove_tags=["#draft"])
-
-# Rename a tag everywhere
-tag_rename(old_tag="#hmem-store", new_tag="#hmem")
-```
-
-Use `tag_bulk` when adding a new systematic tag to an existing category, or cleaning up after a tagging convention change. `tag_rename` handles typos or renames across the entire memory.
-
----
-
-## H-Prefix: User Skill Assessment
-
-Actively track the user's expertise level across topics. This drives how you communicate —
-a coding expert doesn't need variable explanations, a beginner doesn't need jargon.
-
-### Structure
-
-One H-entry per main topic, with sub-nodes per subtopic:
-
-```
-write_memory(prefix="H", content="User Skill: IT
-	Coding — Advanced: writes TypeScript fluently, debugs SQLite schemas, understands async/MCP
-	Terminal/CLI — Advanced: bash, git, systemctl, nvm, sqlite3 comfortable
-	Networking — Intermediate: HTTP/DNS solid, asked about WebSocket details
-	DevOps — Intermediate: systemd + nvm yes, Docker unfamiliar",
-  tags=["#skill-assessment", "#it"])
-```
-
-Levels: **1-10 scale** (see user-assessment skill for full details).
-1-2 = no experience, 5-6 = intermediate, 9-10 = expert. Half-points allowed.
-
-Always include evidence (observed behavior, not assumptions).
-
-### When to assess
-
-- **First interaction**: Make initial assessment from vocabulary, questions, and tool usage
-- **Ongoing (every few exchanges)**: Watch for signals:
-  - **Upgrade signals**: uses domain-specific terms correctly, solves problems independently, corrects the agent
-  - **Downgrade signals**: "das verstehe ich nicht", "explain that", asks about basic concepts, misuses terms
-- **On /save**: Review and update assessments if evidence accumulated
-
-### How to update
-
-Reference the O-entry (automatic session log) where the skill change was observed:
-
-```
-# User demonstrated new skill — link to the exchange that proves it
-append_memory(id="H0010", content="Docker — Intermediate: configured docker-compose independently (see O0042.15)")
-
-# User's skill improved
-update_memory(id="H0010.3", content="Networking — Advanced: configures DNS, TLS, reverse proxies (see O0042.23)")
-
-# User struggled — downgrade with evidence
-update_memory(id="H0010.4", content="DevOps — Beginner: asked what systemd is, needed step-by-step (see O0042.8)")
-```
-
-The O-entry reference lets future agents verify the assessment by reading the original conversation.
-
-### How to USE assessments
-
-Before explaining anything technical, check the relevant H-entry:
-
-- **Beginner**: Explain concepts, use analogies, avoid jargon, step-by-step
-- **Intermediate**: Brief explanations, some jargon OK, link to docs for details
-- **Advanced**: Direct technical language, skip basics, focus on trade-offs
-- **Expert**: Peer-level discussion, challenge assumptions, discuss edge cases
-
-Example: If H0010.1 says "Coding — Advanced", don't explain what a Map is.
-If H0010.4 says "DevOps — Beginner", explain what a systemd service does before configuring one.
-
-### Topics are open-ended
-
-Not just IT — any domain the user works in:
-- Music (theory, instruments, production)
-- Mechanical (bikes, cars, tools)
-- Business (accounting, marketing, management)
-- Languages (German, English proficiency)
-
-Create new H-entries as topics emerge naturally from conversation.
-
----
-
 ## Language Consistency
 
-Match the language of existing entries. Before writing, check what language the memory store uses (run `read_memory()` if unsure). If existing entries are in German, write in German. If English, write in English. Do not mix languages within a single store — it makes search and curation harder.
+Match the language of existing entries. Before writing, check what language the memory store uses (run `read_memory()` if unsure). Do not mix languages within a single store.
 
 ## Anti-Patterns
 
@@ -551,11 +220,11 @@ Match the language of existing entries. Before writing, check what language the 
 |-------|-------|
 | L1 too short: "Fixed bug" | Full sentence with root cause + blank line + body |
 | Writing English when existing entries are German | Match the store's language |
-| Tabs inside content text (e.g. code snippets) | Use spaces for indentation within content — tabs at line start always mean "go deeper in the hierarchy" |
-| Mixed spaces and tabs for hierarchy | Stay consistent — either tabs or spaces as your depth marker |
+| Tabs inside content text (e.g. code snippets) | Use spaces for indentation within content |
+| Mixed spaces and tabs for hierarchy | Stay consistent with one depth marker |
 | Everything flat, no indentation | Use hierarchy — L2/L3 for details |
 | Save trivial things | Quality over quantity |
 | Forget to write_memory | Always call BEFORE setting Status: Completed |
-| Write to .hmem via sqlite3/SQL | ONLY use `write_memory` MCP tool — never raw SQL |
-| MCP unavailable → skip saving | Reconnect MCP first (`/mcp` or restart tool) |
-| `update_memory(id="X", obsolete=true)` without `[✓ID]` | Write correction first, then mark obsolete with `[✓E0076]` tag |
+| Write to .hmem via sqlite3/SQL | ONLY use `write_memory` MCP tool |
+| MCP unavailable -> skip saving | Reconnect MCP first (`/mcp` or restart tool) |
+| `update_memory(id="X", obsolete=true)` without correction ref | Write correction first, then mark obsolete |

--- a/skills/hmem-write/references/E-SCHEMA.md
+++ b/skills/hmem-write/references/E-SCHEMA.md
@@ -1,0 +1,52 @@
+# E-Entry Schema (Auto-Scaffolded)
+
+E-entries have a **pre-built structure** — just provide a title and short description, the server creates the rest.
+
+## Creating an E-Entry
+
+```
+write_memory(prefix="E", content="hmem sync bug on v1.0.1\n\nConnection fails when HMEM_PATH contains spaces", tags=["#hmem", "#sync", "#path"])
+```
+
+This auto-creates:
+- **.1 Analysis** (your description goes here automatically)
+- **.2 Possible fixes**
+- **.3 Fixing attempts**
+- **.4 Solution**
+- **.5 Cause**
+- **.6 Key Learnings**
+
+Plus `#open` tag. Fill in the nodes as you debug with `append_memory`/`update_memory`. The response shows **similar E/D entries by tag overlap** — check them before reinventing the wheel. When solved, replace `#open` with `#solved` and fill .4 + .5 + .6.
+
+E-entries are **not shown in bulk reads** — they surface automatically via tag overlap when you create new E/D entries. Solved bugs are knowledge, not clutter.
+
+## Marking Entries as Favorites
+
+Mark any entry as a favorite to ensure it always appears with its L2 detail in bulk reads (alongside a `[heart]` marker). Use this for reference info you need to see every session — API endpoints, key decisions, frequently looked-up patterns.
+
+```
+write_memory(prefix="D", content="...", favorite=true)           # set at creation
+update_memory(id="D0010", content="...", favorite=true)          # set on existing
+update_memory(id="D0010", content="...", favorite=false)         # clear
+```
+
+Favorites are **not** a prefix — they are a flag on any entry regardless of category.
+Use sparingly: if everything is a favorite, nothing is. Prefer high-value reference entries over fleeting notes.
+
+## Marking Entries as Obsolete
+
+When an entry is outdated — superseded by a newer approach, a fixed bug, or changed architecture — do **not** delete it. Mark it as obsolete with a correction reference:
+
+```
+# Step 1: Write the correction FIRST
+write_memory(prefix="E", content="Correct approach is XYZ\n\tDetails...")  # -> E0076
+
+# Step 2: Mark old entry obsolete — MUST include [checkmark-ID] tag
+update_memory(id="E0023", content="Wrong approach — see [checkmark-E0076]", obsolete=true)
+```
+
+**The `[checkmark-ID]` tag is enforced.** The system will reject `obsolete=true` without a correction reference. This ensures every obsolete entry points to its replacement. The system also creates **bidirectional links** automatically (E0023<->E0076).
+
+The entry stays in memory with a `[!]` marker. Past errors still carry learning value. The curator may eventually prune it, but that is their decision.
+
+**Shortcut for stale entries:** If no correction exists (entry is just old/irrelevant, not wrong), only the curator can mark it obsolete without `[checkmark-ID]`.

--- a/skills/hmem-write/references/H-ASSESSMENT.md
+++ b/skills/hmem-write/references/H-ASSESSMENT.md
@@ -1,0 +1,69 @@
+# H-Prefix: User Skill Assessment
+
+Actively track the user's expertise level across topics. This drives how the agent communicates —
+a coding expert does not need variable explanations, a beginner does not need jargon.
+
+## Structure
+
+One H-entry per main topic, with sub-nodes per subtopic:
+
+```
+write_memory(prefix="H", content="User Skill: IT
+	Coding — Advanced: writes TypeScript fluently, debugs SQLite schemas, understands async/MCP
+	Terminal/CLI — Advanced: bash, git, systemctl, nvm, sqlite3 comfortable
+	Networking — Intermediate: HTTP/DNS solid, asked about WebSocket details
+	DevOps — Intermediate: systemd + nvm yes, Docker unfamiliar",
+  tags=["#skill-assessment", "#it"])
+```
+
+Levels: **1-10 scale** (see user-assessment skill for full details).
+1-2 = no experience, 5-6 = intermediate, 9-10 = expert. Half-points allowed.
+
+Always include evidence (observed behavior, not assumptions).
+
+## When to Assess
+
+- **First interaction**: Make initial assessment from vocabulary, questions, and tool usage
+- **Ongoing (every few exchanges)**: Watch for signals:
+  - **Upgrade signals**: uses domain-specific terms correctly, solves problems independently, corrects the agent
+  - **Downgrade signals**: "das verstehe ich nicht", "explain that", asks about basic concepts, misuses terms
+- **On /save**: Review and update assessments if evidence accumulated
+
+## How to Update
+
+Reference the O-entry (automatic session log) where the skill change was observed:
+
+```
+# User demonstrated new skill — link to the exchange that proves it
+append_memory(id="H0010", content="Docker — Intermediate: configured docker-compose independently (see O0042.15)")
+
+# User's skill improved
+update_memory(id="H0010.3", content="Networking — Advanced: configures DNS, TLS, reverse proxies (see O0042.23)")
+
+# User struggled — downgrade with evidence
+update_memory(id="H0010.4", content="DevOps — Beginner: asked what systemd is, needed step-by-step (see O0042.8)")
+```
+
+The O-entry reference lets future agents verify the assessment by reading the original conversation.
+
+## How to USE Assessments
+
+Before explaining anything technical, check the relevant H-entry:
+
+- **Beginner**: Explain concepts, use analogies, avoid jargon, step-by-step
+- **Intermediate**: Brief explanations, some jargon OK, link to docs for details
+- **Advanced**: Direct technical language, skip basics, focus on trade-offs
+- **Expert**: Peer-level discussion, challenge assumptions, discuss edge cases
+
+Example: If H0010.1 says "Coding — Advanced", do not explain what a Map is.
+If H0010.4 says "DevOps — Beginner", explain what a systemd service does before configuring one.
+
+## Topics Are Open-Ended
+
+Not just IT — any domain the user works in:
+- Music (theory, instruments, production)
+- Mechanical (bikes, cars, tools)
+- Business (accounting, marketing, management)
+- Languages (German, English proficiency)
+
+Create new H-entries as topics emerge naturally from conversation.

--- a/skills/hmem-write/references/P-SCHEMA.md
+++ b/skills/hmem-write/references/P-SCHEMA.md
@@ -1,0 +1,53 @@
+# P-Entry Standard Schema
+
+Every project entry MUST follow this structure. The MCP server validates L2 nodes
+against the standard categories when `prefix="P"`.
+
+## L1 Format
+
+**L1 Title:** `Name | Status | Tech Stack | GH: owner/repo | Short description`
+The GH field is optional — include it when a GitHub repo exists, omit otherwise.
+**L1 Body:** (same line or next non-indented line) One-sentence project summary.
+
+## Status Values
+
+| Status | Meaning |
+|--------|---------|
+| New | Just started, concept phase |
+| Active | In active development |
+| Mature | Feature-complete, only bugfixes |
+| Paused | On hold, will resume later |
+| Archived | Done or abandoned |
+
+## L2 Categories (fixed order, skip empty sections)
+
+The MCP server validates that L2 nodes start with one of these names. Minimum for a new project: Overview + Codebase (or Usage).
+
+| L2 Category | What goes here | L3 children |
+|-------------|---------------|-------------|
+| **Overview** | First thing an agent reads (like CLAUDE.md /init) | Current state, Goals, Architecture, Environment |
+| **Codebase** | Code structure — NO code, only names + signatures | Entry point, Core modules (each module = L4 node with signature + purpose + return), Helpers, Config, Tests |
+| **Usage** | How the project is used | Installation/Setup, CLI/API commands, Common workflows |
+| **Context** | Background and motivation | Initiator, Target audience, Business context, Dependencies (links) |
+| **Deployment** | Build/CI/CD/publish process | (flat or with L3 sub-steps) |
+| **Bugs** | Active bugs + known limitations | L3: inline report (symptom + cause) OR pointer to E-entry (`-> E0097`). L4: reproduction steps |
+| **Protocol** | Session log, chronological | One-liner per session + links to O-entries |
+| **Open tasks** | Project-specific TODOs | One per L3 node. Cross-project tasks -> T-prefix with links |
+| **Ideas** | Feature ideas, brainstorming | L3: short description, L4: implementation details |
+
+## load_project Tool
+
+Use `load_project(id="P0048")` to activate a project and get the full briefing (L2 content + L3 titles) in one call. This is the recommended way to start working on a project — it combines read + activate.
+
+## Complete P-Entry Example (WeatherBot)
+
+```
+write_memory(
+  prefix="P",
+  content="WeatherBot | New | Python/Discord.py | GH: user/weatherbot\n\nDiscord bot for weather forecasts — slash commands for current weather and multi-day forecasts\n\tOverview\n\t\tCurrent state\n\n\t\tScaffolding done, no commands yet. Bot connects to Discord but has no slash commands registered.\n\t\tGoals\n\n\t\tDaily/hourly forecasts via slash commands, multi-city support, embed formatting\n\t\tArchitecture\n\n\t\tDiscord slash command -> OpenWeatherMap API -> formatted embed. Single-file cog pattern.\n\t\tEnvironment\n\n\t\t/home/user/weatherbot, python bot.py, needs DISCORD_TOKEN + WEATHER_API_KEY in .env\n\tCodebase\n\t\tEntry point — bot.py, start: python bot.py\n\t\tCore modules\n\t\t\tweather_cog.py — WeatherCog(Cog); fetch_forecast(city: str) -> discord.Embed\n\t\t\tformatter.py — format_embed(data: dict) -> discord.Embed\n\t\tHelpers / Utilities\n\t\t\tapi_client.py — get_weather(city: str) -> dict; wraps HTTP to OpenWeatherMap\n\t\tConfig / Constants — .env: DISCORD_TOKEN, WEATHER_API_KEY, DEFAULT_CITY\n\t\tTests — pytest, test_weather_cog.py (3 tests)\n\tUsage\n\t\tInstallation / Setup — pip install -r requirements.txt, cp .env.example .env\n\t\tCLI / API — /weather <city>, /forecast <city> (planned)\n\tContext\n\t\tInitiator — personal project, Mar 2026\n\t\tTarget audience — personal Discord server\n\t\tDependencies — discord.py, OpenWeatherMap API, aiohttp\n\tOpen tasks\n\t\tImplement /forecast command\n\n\t\tMulti-day view with daily highs/lows and weather icons per day\n\t\tAdd city autocomplete",
+  tags=["#discord", "#python", "#weather", "#bot"],
+  links=[]
+)
+```
+
+Note: L2 nodes use 1 tab, L3 uses 2 tabs, L4 uses 3 tabs. Separate title from body with a blank line at the same indent level. Skip empty sections — no need for placeholder text.

--- a/skills/hmem-write/references/PREFIXES.md
+++ b/skills/hmem-write/references/PREFIXES.md
@@ -1,0 +1,112 @@
+# Prefixes, Markers, and Bulk Tag Operations
+
+## Prefix Table
+
+| Prefix | Category | When to use |
+|--------|----------|-------------|
+| **P** | (P)roject | Project entries — standardized L1 format (see P-SCHEMA.md) |
+| **L** | (L)esson | Lessons learned, best practices — cross-project knowledge |
+| **E** | (E)rror | Bugs, errors + their fix — auto-scaffolded schema (see E-SCHEMA.md) |
+| **D** | (D)ecision | Architecture decisions with reasoning — cross-project knowledge |
+| **T** | (T)ask | Cross-project or infrastructure tasks ONLY (see note below) |
+| **M** | (M)ilestone | Cross-project milestones ONLY — project milestones go in P-entry L2 "Protocol" |
+| **S** | (S)kill | Skills, processes, how-to guides |
+| **N** | (N)avigator | Code pointers — where something lives in the codebase |
+| **H** | (H)uman | Knowledge about the user — preferences, context, working style |
+| **R** | (R)ule | User-defined rules and constraints — "always do X", "never do Y" |
+| **I** | (I)nfrastructure | Devices, servers, deployments, network — one entry per device/server |
+
+## Where Do Tasks, Errors, Lessons, and Decisions Go?
+
+**Tasks** belong inside the project's P-entry L2 "Open tasks" node:
+```
+append_memory(id="P0048.8", content="Implement multi-server sync\n\tPush/pull to all configured servers", tags=["#hmem-sync"])
+```
+Use the T-prefix ONLY for tasks that span multiple projects or are infrastructure/meta tasks (e.g. "Set up Strato server", "Run curation pass"). These get `links=["P00XX"]` to the most relevant project.
+
+**Milestones** belong in the P-entry L2 "Protocol" node as a chronological entry:
+```
+append_memory(id="P0048.7", content="v4.0.0 published — project gate + load_project tool (2026-03-27)", tags=["#release"])
+```
+Use the M-prefix ONLY for milestones that span multiple projects (e.g. "First cross-device sync working").
+
+**Errors (E), Lessons (L), Decisions (D)** stay as independent root entries — they are **cross-project knowledge**. An SQLite lesson learned in hmem applies to every SQLite project. Always add `tags` and `links` to connect them back:
+```
+write_memory(prefix="E", content="...", tags=["#hmem", "#sqlite"], links=["P0048"])
+```
+
+**P-entry "Known issues" (L2)** contains short summaries pointing to E-entries — not the errors themselves:
+```
+append_memory(id="P0048.6", content="Auto-sync fails with multiple .hmem in CWD -> E0097, T0043", tags=["#hmem-sync"])
+```
+
+## Custom Prefixes
+
+If none of the above fit, use any single uppercase letter. To register it officially (so the system validates it), add it to `hmem.config.json` under `"prefixes"`:
+```json
+{ "prefixes": { "R": "Research" } }
+```
+Custom prefixes are merged with the defaults — they do not replace them. Without registering, the system will reject the prefix.
+
+## Markers
+
+| Marker | Meaning |
+|--------|---------|
+| `[heart]` | Favorite — always expanded in bulk reads |
+| `[star]` | Top-accessed — high weighted access score |
+| `[triple-bar]` | Top-subnode — many children |
+| `[lightning]` | Task-promoted — relevant to an active T/P/D entry (tag overlap) |
+| `[*]` | Active — currently in focus |
+| `[P]` | Pinned — super-favorite, shows full L2 |
+| `[!]` | Obsolete — superseded, kept for history |
+| `[-]` | Irrelevant — hidden from bulk reads |
+| `checkmark` | Synced — backed up to all sync servers |
+
+## N — Navigator (Code Pointers)
+
+Use `N` to save a pointer to a specific file, function, or code location so the agent does not have to search for it next session.
+
+```
+write_memory(
+  prefix="N",
+  content="Link resolution in read_memory call
+	src/hmem-store.ts ~line 269 — read() method, ID branch
+	Guard: resolveLinks !== false prevents circular refs
+	Introduced in v1.4.0",
+  links=["E0069"]
+)
+```
+
+**L1:** What it is — one sentence describing the concept/feature
+**L2:** Exact file path + line range + function/method name
+**L3:** Context, caveats, related patterns
+**Links:** Related entries (errors, decisions, lessons)
+
+Update N entries whenever code has moved or logic has changed. Stale pointers are worse than none. If the pointer cannot be verified, mark it obsolete.
+
+## Bulk Tag Operations
+
+Apply tags to multiple entries at once, or rename a tag everywhere:
+
+```
+# Add #bugfix to all E-prefix entries
+tag_bulk(filter={prefix: "E"}, add_tags=["#bugfix"])
+
+# Add tag to entries matching a search term
+tag_bulk(filter={search: "FTS5"}, add_tags=["#search", "#sqlite"])
+
+# Remove #old from all entries that have it
+tag_bulk(filter={tag: "#old"}, remove_tags=["#old"])
+
+# Add and remove simultaneously
+tag_bulk(filter={prefix: "L", tag: "#draft"}, add_tags=["#stable"], remove_tags=["#draft"])
+
+# Rename a tag everywhere
+tag_rename(old_tag="#hmem-store", new_tag="#hmem")
+```
+
+Use `tag_bulk` when adding a new systematic tag to an existing category, or cleaning up after a tagging convention change. `tag_rename` handles typos or renames across the entire memory.
+
+## Access Count (Automatic + Time-Weighted)
+
+Access counts are managed automatically — every `read_memory` and `append_memory` call bumps the accessed entries. The ranking uses **time-weighted scoring** (`access_count / log2(age_in_days + 2)`) so newer entries with fewer accesses can outrank stale old ones. Entries with the highest weighted scores get `[star]` markers and expanded treatment in bulk reads. To explicitly mark an entry as important, use `favorite: true` on `write_memory` or `update_memory`.


### PR DESCRIPTION
Hey @Bumblebiber 👋

5-level lazy loading that fits 300+ memories into 5k tokens, with Haiku background checkpoints that extract lessons without interrupting the main agent. This is the most thoughtful approach to persistent AI memory I've seen. The per-session state isolation in v6.2.0 (PPID bridges, session marker files) shows you're solving the hard problems that most memory systems ignore entirely. I'd like to suggest some improvements to a few of the skill files.

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/8aa2ccc8-036a-4fb5-9749-40437a31f721" />


<details>
<summary>Changes summary</summary>

**hmem-write (+50%)** — the biggest win:
- Rewrote the description with concrete actions, natural trigger terms ("remember this", "save this", "don't forget"), and an explicit "Use when..." clause — previous description scored 7% on specificity
- Reduced from 562 to 230 lines by extracting reference material into references/ files
- Created references/P-SCHEMA.md (P-entry schema + WeatherBot example), references/E-SCHEMA.md (E-entry scaffolding), references/H-ASSESSMENT.md (user skill assessment guide), references/PREFIXES.md (prefix table, markers, bulk tag operations)
- Kept core workflow: syntax, tree-navigation protocol, when-to-save rules, update vs append decision table
- Removed explanatory text Claude can infer (WAL journaling details, etc.)

**hmem-config (+18%)**:
- Reduced from 263 to 132 lines by extracting Windows hook config, entry schemas, bulk-read tuning, and sync troubleshooting into references/ files
- Condensed parameter tables — removed verbose prose, kept defaults + ranges
- Created references/WINDOWS-HOOKS.md, references/SCHEMAS.md, references/BULK-READ.md, references/SYNC-TROUBLESHOOTING.md

**hmem-update (+12%)**:
- Reduced from 379 to 187 lines extracted version-specific migrations (v5.1.0, v5.1.2, v6.0.0), Windows hook troubleshooting, and P-entry schema into references/ files
- Kept the full 9-step workflow structure with concise summaries
- Created references/MIGRATIONS.md, references/WINDOWS-HOOKS.md, references/SCHEMA.md

**hmem-setup (+9%)**:
- Improved description with additional trigger terms ("set up memory", "initialize hmem", "first-time setup")
- Reduced from 269 to 173 lines by extracting hook reference and config reference
- Created references/HOOKS.md, references/CONFIG.md

**hmem-read (+4%)**:
- Reduced from 405 to 223 lines by extracting time-based search, proactive curation, and health audit into references/ files
- Removed verbose explanations ("Why load_project over read_memory", "Title vs. Body")
- Created references/TIME-SEARCH.md, references/CURATION.md, references/HEALTH-AUDIT.md

</details>

The common pattern across all changes: extracting reference material into references/ subdirectories for better progressive disclosure, trimming explanatory text the agent can infer, and ensuring descriptions have strong trigger terms and "Use when..." clauses. No domain expertise or workflows were removed, just restructured for better token efficiency.

Honest disclosure. I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@yogesh-tessl](https://github.com/yogesh-tessl) - if you hit any snags.

Thanks in advance 🙏